### PR TITLE
fix: reset/close the connection when waitAck changes

### DIFF
--- a/src/lotus.cpp
+++ b/src/lotus.cpp
@@ -1601,6 +1601,12 @@ namespace fcitx {
                         break;
                     }
                 }
+                // if waitAck changed, close stale connection to flush any buffered acks
+                if (needWaitAck != waitAck && uinput_client_fd_ >= 0) {
+                    // init client connection
+                    close(uinput_client_fd_);
+                    uinput_client_fd_ = -1;
+                }
                 waitAck = needWaitAck;
             }
         }


### PR DESCRIPTION
fix

GOOD, app đầu mở là chromium x11 
```
   CLIENT                                SERVER
   ----------------                      ----------------
   Chromium x11 (waitAck = true)

   send(2)  -------------------------->  do [send backspace]
                                         send ACK
   recv()   <--------------------------  ACK
   (blocks until ACK arrives)
   (fd remains OPEN)
```
BADDD, Đổi từ firefox wayland sang chroium x11
```
   Firefox wyland (waitAck = false)

   send(2)  -------------------------->  do [send backspace]
   (skip recv)                           send ACK
   nobody reads ACK
   [ACK stays in socket buffer]
   (fd still OPEN)


   switch to chromium x11 (waitAck = true)

   send(2)  -------------------------->  server starts [send backspace]
   recv()   <--------------------------  reads OLD ACK <-- BADDDD
   (returns immediately)
   client thinks operation finished
```