### PR TITLE
fix edge case send extra backspace

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -173,7 +173,7 @@ namespace fcitx {
             return false;
         }
 
-        if (textLen - 1 > static_cast<size_t>(cursor) && cursor == realtextLen)
+        if (textLen - 1 > static_cast<size_t>(cursor) && cursor == realtextLen && text.find('\n', cursor) == std::string::npos)
             return true;
 
         if (realtextLen < cursor)


### PR DESCRIPTION
bug in firefox wayland. surroundingText is include "\n"+ `<n char>` in the nextline after cursor