### PR TITLE
fix: buffer and replay keys dropped during rapid typing

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -466,7 +466,7 @@ namespace fcitx {
                 pending_commit_string_   = "";
 
                 event.filterAndAccept(); // Filter out the final trigger backspace.
-                replayBufferedKeys(!isBackspace(currentSym), sleepTime);
+                replayBufferedKeys();
                 return true;
             }
         }
@@ -828,7 +828,7 @@ namespace fcitx {
             }
             replacement_thread_id_.store(0, std::memory_order_release);
             replacement_start_ms_.store(0, std::memory_order_release);
-            replayBufferedKeys(true, 20);
+            replayBufferedKeys();
         }
         if (keyEvent.rawKey().check(FcitxKey_Shift_L) || keyEvent.rawKey().check(FcitxKey_Shift_R))
             return;
@@ -972,9 +972,7 @@ namespace fcitx {
         return history_.empty();
     }
 
-    void LotusState::replayBufferedKeys(bool checkEmptyPreedit, int sleepTime) {
-        (void)checkEmptyPreedit;
-        (void)sleepTime;
+    void LotusState::replayBufferedKeys() {
         if (buffered_keys_.empty()) {
             return;
         }

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -189,14 +189,11 @@ namespace fcitx {
         /**
          * @brief Replays keystrokes buffered during replacement.
          *
-         * When is_deleting_ is true, non-backspace keystrokes are buffered
+         * When is_deleting_ is true, non-special keystrokes are buffered
          * instead of being discarded. This method replays them after the
          * replacement completes.
-         *
-         * @param checkEmptyPreedit Whether to check for empty preedit.
-         * @param sleepTime Delay in milliseconds for uinput mode.
          */
-        void replayBufferedKeys(bool checkEmptyPreedit, int sleepTime);
+        void replayBufferedKeys();
 
         friend class EmojiCandidateWord;
         friend class LotusEngine;


### PR DESCRIPTION
Sửa lỗi mất phím phía sau khi gõ nhanh trên Chromium/Wayland/Electron (ví dụ gõ "bán" thành "bá").

Root cause là `is_deleting_` đang khóa phím mới đến trong lúc chờ update chuỗi preedit.

### Giải pháp:

**Buffer phím**: Thay vì bỏ qua, tạm lưu các phím hợp lệ (cố ký tự utf-8) vào buffered_keys_.
**Replay phím**: Đẩy phím ở buffer vào engine xử lý lại ngay khi quá trình replacement kết thúc.
Cập nhật oldPreBuffer_ sau replay tránh sai state ở lần gõ sau.