### PR TITLE
fix(uinput): fix macro in rofi

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -602,10 +602,16 @@ namespace fcitx {
             if (!deletedPart.empty()) {
                 performReplacement(deletedPart, addedPart);
                 keyEvent.filterAndAccept();
-            } else if (!addedPart.empty() && keyUtf8 != addedPart) {
-                ic_->commitString(addedPart);
-                keyEvent.filterAndAccept();
             } else {
+                if (!addedPart.empty() && keyUtf8 != addedPart) {
+                    // Stripping the trigger key (space) from addedPart
+#if __cplusplus >= 202002L
+                    addedPart.resize(addedPart.size() - 1);
+#else
+                    addedPart = addedPart.substr(0, addedPart.size() - 1);
+#endif
+                    ic_->commitString(addedPart);
+                }
                 keyEvent.forward();
             }
 


### PR DESCRIPTION
fix edge case khi macro có kiểu (key:value) trong đó key là substr của value, và value bắt đầu bằng substr. vd: (lmf:lmfao) khi nhập trên rofi (wayland) `lmf` + `<space>` thì phải "đợi 1 lúc"/"nhấn thêm key nữa" nó mới hiện `lmfao`