### PR TITLE
Fix disappearing preedit text when switching modes

### DIFF
--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -459,8 +459,6 @@ namespace fcitx {
                     appRules_[currentConfigureApp_] = selectedMode;
                     saveAppRules();
                 }
-
-                setMode(selectedMode, ic);
                 selectionMade = true;
             }
 
@@ -470,6 +468,9 @@ namespace fcitx {
                 ic->updateUserInterface(UserInterfaceComponent::InputPanel);
                 auto* state = ic->propertyFor(&factory_);
                 state->reset();
+                if (selectedMode != LotusMode::NoMode) {
+                    setMode(selectedMode, ic);
+                }
             }
             return;
         }
@@ -622,8 +623,8 @@ namespace fcitx {
                     saveAppRules();
                 }
 
-                setMode(mode, ic);
                 cleanup(ic);
+                setMode(mode, ic);
             };
         };
 


### PR DESCRIPTION
### Description
PR này sửa lỗi văn bản preedit (ví dụ: "khô gà") bị biến mất hoặc gây ra hành vi không nhất quán (như phải bấm Space hai lần mới xuất hiện lại) khi chuyển từ chế độ Preedit sang Off.

[Screencast_20260312_213036.webm](https://github.com/user-attachments/assets/a129fbbd-0ef4-49d5-91c6-1b035a5ea84f)

### Root Cause
Nguyên nhân là do thứ tự thực hiện không đúng trong logic chuyển đổi chế độ. Biến toàn cục `realMode` được cập nhật sang giá trị mới trước khi thực hiện reset state cho input context hiện tại.

Bên trong `LotusState::reset()`, logic sẽ rẽ nhánh dựa trên giá trị của `realMode`. Nếu realMode đã được chuyển sang Off (0), các bước dọn dẹp dành riêng cho chế độ Preedit (như commit buffer và xóa preedit hiển thị phía client) sẽ bị bỏ qua. Điều này để lại một buffer preedit "mồ côi" trong các ứng dụng, dẫn đến các lỗi quan sát được.

### Changes
Đã sửa đổi `src/lotus-engine.cpp` để đảm bảo việc cleanup diễn ra trước khi cập nhật biến mode toàn cục:

- Đảo thứ tự `cleanup(ic)` và `setMode(mode, ic)` trong phần chọn mode từ menu.
- Đảm bảo `state->reset()` được gọi trước `setMode(selectedMode, ic)` trong logic chọn mode nhanh bằng phím tắt.

### Test
[Screencast_20260312_215516.webm](https://github.com/user-attachments/assets/fff132e9-8e46-40da-9764-7a2af8123b6a)
