### PR TITLE
Implement double space to period feature with configuration option

### DIFF
--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -196,6 +196,7 @@ namespace fcitx {
         OptionWithAnnotation<std::string, StringListAnnotation> outputCharset{this, "OutputCharset", _("Output Charset"), "Unicode", {}, {}, StringListAnnotation()};
         Option<bool> spellCheck{this, "SpellCheck", _("Enable Spell Check"), true}; Option<bool> enableMacro{this, "EnableMacro", _("Enable Macro"), true};
         Option<bool>                                                                             capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true};
+        Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
         Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
         Option<bool> modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
         Option<bool> freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -194,16 +194,15 @@ namespace fcitx {
         Option<std::string, InputMethodConstrain, DefaultMarshaller<std::string>, InputMethodAnnotation> inputMethod{
             this, "InputMethod", _("Input Method"), "Telex", InputMethodConstrain(&inputMethod), {}, InputMethodAnnotation()};
         OptionWithAnnotation<std::string, StringListAnnotation> outputCharset{this, "OutputCharset", _("Output Charset"), "Unicode", {}, {}, StringListAnnotation()};
-        Option<bool>                                                                             spellCheck{this, "SpellCheck", _("Enable Spell Check"), true};
-        Option<bool>                                                                             enableMacro{this, "EnableMacro", _("Enable Macro"), true};
+        Option<bool> spellCheck{this, "SpellCheck", _("Enable Spell Check"), true}; Option<bool> enableMacro{this, "EnableMacro", _("Enable Macro"), true};
         Option<bool>                                                                             capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true};
-        Option<bool>                                                                             doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
-        Option<bool>                                                                             autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
-        Option<bool>                                                                             modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
-        Option<bool>                                                                             freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
-        Option<bool>                                                                             ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
-        Option<bool>                                                                             fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        Option<bool>                                                                             useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
+        Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
+        Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
+        Option<bool> modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
+        Option<bool> freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
+        Option<bool> ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
+        Option<bool> fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
+        Option<bool> useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
 #ifdef ENABLE_MACRO_EDITOR
         ExternalOption macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
 #else

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -194,15 +194,16 @@ namespace fcitx {
         Option<std::string, InputMethodConstrain, DefaultMarshaller<std::string>, InputMethodAnnotation> inputMethod{
             this, "InputMethod", _("Input Method"), "Telex", InputMethodConstrain(&inputMethod), {}, InputMethodAnnotation()};
         OptionWithAnnotation<std::string, StringListAnnotation> outputCharset{this, "OutputCharset", _("Output Charset"), "Unicode", {}, {}, StringListAnnotation()};
-        Option<bool> spellCheck{this, "SpellCheck", _("Enable Spell Check"), true}; Option<bool> enableMacro{this, "EnableMacro", _("Enable Macro"), true};
+        Option<bool>                                                                             spellCheck{this, "SpellCheck", _("Enable Spell Check"), true};
+        Option<bool>                                                                             enableMacro{this, "EnableMacro", _("Enable Macro"), true};
         Option<bool>                                                                             capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true};
-        Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
-        Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
-        Option<bool> modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
-        Option<bool> freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
-        Option<bool> ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
-        Option<bool> fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        Option<bool> useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
+        Option<bool>                                                                             doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
+        Option<bool>                                                                             autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
+        Option<bool>                                                                             modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
+        Option<bool>                                                                             freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
+        Option<bool>                                                                             ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
+        Option<bool>                                                                             fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
+        Option<bool>                                                                             useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
 #ifdef ENABLE_MACRO_EDITOR
         ExternalOption macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
 #else

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -70,7 +70,6 @@ namespace fcitx {
             .freeMarking         = *engine_->config().freeMarking,
         };
         EngineSetOption(lotusEngine_.handle(), &option);
-        doubleSpaceConfig_ = *engine_->config().doubleSpaceToPeriod;
     }
 
     bool LotusState::connect_uinput_server() {
@@ -463,7 +462,7 @@ namespace fcitx {
         return false;
     }
 
-    void LotusState::performReplacement(const std::string& deletedPart, const std::string& addedPart, bool triggerKeyFiltered) {
+    void LotusState::performReplacement(const std::string& deletedPart, const std::string& addedPart) {
         LOTUS_INFO("Perform replacement: " + deletedPart + " -> " + addedPart); //NOLINT
         int my_id                = ++current_thread_id_;
         current_backspace_count_ = 0;
@@ -474,7 +473,7 @@ namespace fcitx {
         // The isAutofillCertain function has been optimized to differentiate
         // between browser autofill and AI ghost text.
         int autofillOffset   = isAutofillCertain(surrounding) ? 1 : 0;
-        expected_backspaces_ = static_cast<int>(utf8::length(deletedPart)) + (triggerKeyFiltered ? 0 : 1) + 1 + autofillOffset;
+        expected_backspaces_ = static_cast<int>(utf8::length(deletedPart)) + 1 + autofillOffset;
         replacement_thread_id_.store(my_id, std::memory_order_release);
         replacement_start_ms_.store(now_ms(), std::memory_order_release);
         is_deleting_.store(true, std::memory_order_release);
@@ -595,7 +594,7 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, commonPrefix, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                performReplacement(deletedPart, addedPart, true);
+                performReplacement(deletedPart, addedPart);
                 keyEvent.filterAndAccept();
             } else {
                 if (!addedPart.empty() && keyUtf8 != addedPart) {
@@ -644,7 +643,7 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, commonPrefix, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                performReplacement(deletedPart, addedPart, true);
+                performReplacement(deletedPart, addedPart);
             } else if (!addedPart.empty()) {
                 ic_->commitString(addedPart);
                 LOTUS_INFO("Commit: " + addedPart);
@@ -694,7 +693,7 @@ namespace fcitx {
                 }
 
                 keyEvent.filterAndAccept();
-                performReplacement(deletedPart, addedPart, true);
+                performReplacement(deletedPart, addedPart);
                 oldPreBuffer_ = preeditStr;
             }
         }
@@ -853,7 +852,7 @@ namespace fcitx {
                 break;
             }
             default: { // Uinput, Smooth, etc.
-                performReplacement(" ", ". ", true);
+                performReplacement(" ", ". ");
                 break;
             }
         }
@@ -896,7 +895,7 @@ namespace fcitx {
             replayBufferedKeys();
         }
         const KeySym currentSym = keyEvent.rawKey().sym();
-        if (doubleSpaceConfig_ && realMode != LotusMode::Off) {
+        if (*engine_->config().doubleSpaceToPeriod && realMode != LotusMode::Off) {
             if (currentSym == FcitxKey_space) {
                 if (isPrevSpace_) {
                     keyEvent.filterAndAccept();
@@ -1083,7 +1082,7 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart, true);
+                    performReplacement(deletedPart, addedPart);
                     history_.clear();
                     ResetEngine(lotusEngine_.handle());
                     oldPreBuffer_.clear();
@@ -1124,7 +1123,7 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart, true);
+                    performReplacement(deletedPart, addedPart);
                     history_.clear();
                     ResetEngine(lotusEngine_.handle());
                     oldPreBuffer_.clear();
@@ -1168,7 +1167,7 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart, true);
+                    performReplacement(deletedPart, addedPart);
                     oldPreBuffer_ = preeditStr;
                     return;
                 }

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -70,6 +70,7 @@ namespace fcitx {
             .freeMarking         = *engine_->config().freeMarking,
         };
         EngineSetOption(lotusEngine_.handle(), &option);
+        doubleSpaceConfig_ = *engine_->config().doubleSpaceToPeriod;
     }
 
     bool LotusState::connect_uinput_server() {
@@ -462,7 +463,7 @@ namespace fcitx {
         return false;
     }
 
-    void LotusState::performReplacement(const std::string& deletedPart, const std::string& addedPart) {
+    void LotusState::performReplacement(const std::string& deletedPart, const std::string& addedPart, bool triggerKeyFiltered) {
         LOTUS_INFO("Perform replacement: " + deletedPart + " -> " + addedPart); //NOLINT
         int my_id                = ++current_thread_id_;
         current_backspace_count_ = 0;
@@ -473,7 +474,7 @@ namespace fcitx {
         // The isAutofillCertain function has been optimized to differentiate
         // between browser autofill and AI ghost text.
         int autofillOffset   = isAutofillCertain(surrounding) ? 1 : 0;
-        expected_backspaces_ = static_cast<int>(utf8::length(deletedPart)) + 1 + autofillOffset;
+        expected_backspaces_ = static_cast<int>(utf8::length(deletedPart)) + (triggerKeyFiltered ? 0 : 1) + 1 + autofillOffset;
         replacement_thread_id_.store(my_id, std::memory_order_release);
         replacement_start_ms_.store(now_ms(), std::memory_order_release);
         is_deleting_.store(true, std::memory_order_release);
@@ -594,7 +595,7 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, commonPrefix, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                performReplacement(deletedPart, addedPart);
+                performReplacement(deletedPart, addedPart, true);
                 keyEvent.filterAndAccept();
             } else {
                 if (!addedPart.empty() && keyUtf8 != addedPart) {
@@ -643,7 +644,7 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, commonPrefix, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                performReplacement(deletedPart, addedPart);
+                performReplacement(deletedPart, addedPart, true);
             } else if (!addedPart.empty()) {
                 ic_->commitString(addedPart);
                 LOTUS_INFO("Commit: " + addedPart);
@@ -693,7 +694,7 @@ namespace fcitx {
                 }
 
                 keyEvent.filterAndAccept();
-                performReplacement(deletedPart, addedPart);
+                performReplacement(deletedPart, addedPart, true);
                 oldPreBuffer_ = preeditStr;
             }
         }
@@ -842,6 +843,22 @@ namespace fcitx {
         }
     }
 
+    void LotusState::handleDoubleSpaceReplacement() {
+        switch (realMode) {
+            case LotusMode::SurroundingText:
+            case LotusMode::Preedit: {
+                ic_->deleteSurroundingText(-1, 1);
+                ic_->commitString(". ");
+                LOTUS_INFO("Commit: . ");
+                break;
+            }
+            default: { // Uinput, Smooth, etc.
+                performReplacement(" ", ". ", true);
+                break;
+            }
+        }
+    }
+
     void LotusState::keyEvent(KeyEvent& keyEvent) {
         if (!lotusEngine_ || keyEvent.isRelease())
             return;
@@ -877,9 +894,20 @@ namespace fcitx {
             replacement_start_ms_.store(0, std::memory_order_release);
             replayBufferedKeys();
         }
-        if (keyEvent.rawKey().check(FcitxKey_Shift_L) || keyEvent.rawKey().check(FcitxKey_Shift_R))
-            return;
         const KeySym currentSym = keyEvent.rawKey().sym();
+        if (doubleSpaceConfig_ && realMode != LotusMode::Off) {
+            if (currentSym == FcitxKey_space) {
+                if (isPrevSpace_) {
+                    keyEvent.filterAndAccept();
+                    handleDoubleSpaceReplacement();
+                    isPrevSpace_ = false;
+                    return;
+                }
+                isPrevSpace_ = true;
+            } else {
+                isPrevSpace_ = false;
+            }
+        }
 
         switch (realMode) {
             case LotusMode::Uinput: {
@@ -923,6 +951,7 @@ namespace fcitx {
         is_deleting_.store(false);
 
         if (lotusEngine_) {
+            isPrevSpace_ = false;
             if (realMode == LotusMode::Preedit) {
                 EngineCommitPreedit(lotusEngine_.handle());
                 UniqueCPtr<char> commit(EnginePullCommit(lotusEngine_.handle()));
@@ -1053,7 +1082,7 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart);
+                    performReplacement(deletedPart, addedPart, true);
                     history_.clear();
                     ResetEngine(lotusEngine_.handle());
                     oldPreBuffer_.clear();
@@ -1094,7 +1123,7 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart);
+                    performReplacement(deletedPart, addedPart, true);
                     history_.clear();
                     ResetEngine(lotusEngine_.handle());
                     oldPreBuffer_.clear();
@@ -1138,7 +1167,7 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart);
+                    performReplacement(deletedPart, addedPart, true);
                     oldPreBuffer_ = preeditStr;
                     return;
                 }

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -878,6 +878,7 @@ namespace fcitx {
             ResetEngine(lotusEngine_.handle());
             is_deleting_.store(false);
             current_backspace_count_ = 0;
+            isPrevSpace_             = false;
             needEngineReset.store(false);
         }
 

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -101,6 +101,8 @@ namespace fcitx {
         std::vector<EmojiEntry> emojiCandidates_;
         bool                    waitAck_ = false;
         std::vector<KeyEntry>   buffered_keys_; ///< Keystrokes buffered during replacement
+        bool                    doubleSpaceConfig_ = false;
+        bool                    isPrevSpace_       = false;
 
         /**
          * @brief Connects to the uinput server.
@@ -169,8 +171,14 @@ namespace fcitx {
          * @brief Performs text replacement via uinput.
          * @param deletedPart Text to delete.
          * @param addedPart Text to insert.
+         * @param triggerKeyFiltered Whether the triggering key was already filtered.
          */
-        void performReplacement(const std::string& deletedPart, const std::string& addedPart);
+        void performReplacement(const std::string& deletedPart, const std::string& addedPart, bool triggerKeyFiltered = false);
+
+        /**
+         * @brief Handles the double space to period replacement.
+         */
+        void handleDoubleSpaceReplacement();
 
         /**
          * @brief Checks and forwards special keys.

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -101,8 +101,7 @@ namespace fcitx {
         std::vector<EmojiEntry> emojiCandidates_;
         bool                    waitAck_ = false;
         std::vector<KeyEntry>   buffered_keys_; ///< Keystrokes buffered during replacement
-        bool                    doubleSpaceConfig_ = false;
-        bool                    isPrevSpace_       = false;
+        bool                    isPrevSpace_ = false;
 
         /**
          * @brief Connects to the uinput server.
@@ -173,7 +172,7 @@ namespace fcitx {
          * @param addedPart Text to insert.
          * @param triggerKeyFiltered Whether the triggering key was already filtered.
          */
-        void performReplacement(const std::string& deletedPart, const std::string& addedPart, bool triggerKeyFiltered = false);
+        void performReplacement(const std::string& deletedPart, const std::string& addedPart);
 
         /**
          * @brief Handles the double space to period replacement.

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -170,7 +170,6 @@ namespace fcitx {
          * @brief Performs text replacement via uinput.
          * @param deletedPart Text to delete.
          * @param addedPart Text to insert.
-         * @param triggerKeyFiltered Whether the triggering key was already filtered.
          */
         void performReplacement(const std::string& deletedPart, const std::string& addedPart);
 


### PR DESCRIPTION
This pull request introduces an experimental "Double Space to Period" feature to the Lotus input method engine and refactors the text replacement logic to support it. The main changes include adding a new configuration option, updating the event handling to detect double spaces, and adjusting the replacement logic to accommodate the new behavior.

**New Feature: Double Space to Period**

* Added a new `doubleSpaceToPeriod` option to `lotus-config.h`, allowing users to enable or disable the experimental feature.
* Introduced `doubleSpaceConfig_` and `isPrevSpace_` member variables to `LotusState` to track the feature's state and previous key presses.
* Updated the configuration loading logic to initialize `doubleSpaceConfig_` based on user settings.

**Event Handling and Replacement Logic**

* Modified the `keyEvent` method to detect consecutive space key presses when the feature is enabled, triggering a period and space insertion.
* Implemented the `handleDoubleSpaceReplacement` method to perform the appropriate text replacement based on the current input mode.
* Ensured `isPrevSpace_` is reset after certain input actions to prevent unintended triggers.

**Refactoring Replacement Functionality**

* Updated the `performReplacement` method to accept a new `triggerKeyFiltered` parameter, allowing more precise control over replacement behavior. [[1]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L465-R466) [[2]](diffhunk://#diff-202258e91df39bca0d689142a4558bbf5a8dc917c064f806b4b5593b14121fc0R174-R181)
* Adjusted all calls to `performReplacement` throughout `lotus-state.cpp` to use the new parameter, ensuring consistent handling with the new feature. [[1]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L476-R477) [[2]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L597-R598) [[3]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L646-R647) [[4]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L696-R697) [[5]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L1056-R1085) [[6]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L1097-R1126) [[7]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L1141-R1170)