### PR TITLE
docs: fix D-Bus session autolaunch on (OpenRC + Wayland)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -486,6 +486,20 @@ Add this line to file `~/.config/kanata/kanata.kbd`
 
 </details>
 
+<details>
+   <summary><b>Additional configurattion for OpenRC</b></summary>
+
+Add this line to `/etc/environment` to fix input issues for X11/XCB applications on Wayland:
+
+```sh
+DBUS_SESSION_BUS_ADDRESS="autolaunch:"
+```
+Or set the env in your DE/WM config (Recommended).
+
+Example for Hyprland: `env = DBUS_SESSION_BUS_ADDRESS,autolaunch:`
+
+</details>
+
 ---
 
 <a id="usage-guide"></a>

--- a/README.md
+++ b/README.md
@@ -485,6 +485,20 @@ Thêm dòng sau vào file `~/.config/kanata/kanata.kbd`
 
 </details>
 
+<details>
+   <summary><b>Cấu hình thêm cho OpenRC</b></summary>
+
+Thêm dòng sau vào `/etc/environment` để fix lỗi không gõ được trên app x11/xcb trên wayland
+
+```sh
+DBUS_SESSION_BUS_ADDRESS="autolaunch:"
+```
+Hoặc set env trong config của DE/WM (Khuyên dùng).
+
+Ví dụ Hyprland: `env = DBUS_SESSION_BUS_ADDRESS,autolaunch:`
+
+</details>
+
 ---
 
 <a id="hướng-dẫn-sử-dụng"></a>


### PR DESCRIPTION
The D-Bus service on OpenRC/systemd provides only the system bus. On non-systemd setups, the lack of a session bus breaks fcitx5 input for chromium, electron,... xcb/x11 apps running on wayland.

Ref: https://codereview.chromium.org/2861163002