### PR TITLE
docs: use unix:path=$XDG_RUNTIME_DIR/bus instead

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -492,11 +492,11 @@ Add this line to file `~/.config/kanata/kanata.kbd`
 Add this line to `/etc/environment` to fix input issues for X11/XCB applications on Wayland:
 
 ```sh
-DBUS_SESSION_BUS_ADDRESS="autolaunch:"
+DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
 ```
 Or set the env in your DE/WM config (Recommended).
 
-Example for Hyprland: `env = DBUS_SESSION_BUS_ADDRESS,autolaunch:`
+Example for Hyprland: `env = DBUS_SESSION_BUS_ADDRESS,unix:path=$XDG_RUNTIME_DIR/bus`
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -491,11 +491,11 @@ Thêm dòng sau vào file `~/.config/kanata/kanata.kbd`
 Thêm dòng sau vào `/etc/environment` để fix lỗi không gõ được trên app x11/xcb trên wayland
 
 ```sh
-DBUS_SESSION_BUS_ADDRESS="autolaunch:"
+DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
 ```
 Hoặc set env trong config của DE/WM (Khuyên dùng).
 
-Ví dụ Hyprland: `env = DBUS_SESSION_BUS_ADDRESS,autolaunch:`
+Ví dụ Hyprland: `env = DBUS_SESSION_BUS_ADDRESS,unix:path=$XDG_RUNTIME_DIR/bus`
 
 </details>
 


### PR DESCRIPTION
fix lỗi set "autolaunch:" làm lỗi dbus không hoạt động đúng cách như mất tray icon, break mako thông báo,...