### PR TITLE
Fix icon of running apps not showing in settings on NixOS

### DIFF
--- a/settings-gui/ui/pages/mode_manager.py
+++ b/settings-gui/ui/pages/mode_manager.py
@@ -235,9 +235,12 @@ class AddAppDialog(QDialog):
                             name = exe_base
                         else:
                             clean = name[1:]
-                            for s in ['-wrapped', '-wrappe', '-wrapp', '-wrap', '-wra', '-wr', '-w']:
-                                if clean.endswith(s):
-                                    clean = clean[:-len(s)]
+                            # On NixOS, wrapped application names from /proc/<pid>/comm can be truncated.
+                            # We check for partial suffixes of "-wrapped", from longest to shortest.
+                            base_suffix = "-wrapped"
+                            for i in range(len(base_suffix), 1, -1):
+                                if clean.endswith(base_suffix[:i]):
+                                    clean = clean[:-i]
                                     break
                             if clean:
                                 name = clean


### PR DESCRIPTION
Mô tả: trên NixOS, tab Applications trong Lotus Settings không hiện icon cho các app đang chạy khi Add Application.

Nguyên nhân:
- Do NixOS không có đường dẫn `/usr/share/applications` như các distro thông thường để settings script tìm file `.desktop`.
- Do một lượng lớn các app trên NixOS chạy thông qua một wrapper, khiến cho tên của các process thường có thêm đuôi -wrapper, -wrap,... nên settings script lấy sai tên ứng dụng.

Giải pháp:
- Bổ sung các đường dẫn applications trên NixOS lấy từ biến `XDG_DATA_DIRS` để script có thể tìm thấy file `.desktop`.
- Xoá các prefix, postfix thường thấy trên NixOS để lấy đúng tên app từ process name