### PR TITLE
Add Ctrl+Backspace support for emoji buffer clearing

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -236,12 +236,14 @@ namespace fcitx {
     }
 
     void LotusState::handleEmojiMode(KeyEvent& keyEvent) {
-        if (keyEvent.key().hasModifier()) {
+        const KeySym currentSym = keyEvent.rawKey().sym();
+        bool isCtrlBackspace = isBackspace(currentSym) &&
+                               (keyEvent.rawKey().states() & KeyState::Ctrl);
+
+        if (keyEvent.key().hasModifier() && !isCtrlBackspace) {
             keyEvent.forward();
             return;
         }
-
-        const KeySym currentSym = keyEvent.rawKey().sym();
 
         auto         baseList   = ic_->inputPanel().candidateList();
         auto         commonList = std::dynamic_pointer_cast<CommonCandidateList>(baseList);
@@ -329,9 +331,13 @@ namespace fcitx {
 
         if (isBackspace(currentSym)) {
             if (!emojiBuffer_.empty()) {
-                emojiBuffer_.pop_back();
-                while (!emojiBuffer_.empty() && (emojiBuffer_.back() & 0xC0) == 0x80) {
+                if (isCtrlBackspace) {
+                    emojiBuffer_.clear();
+                } else {
                     emojiBuffer_.pop_back();
+                    while (!emojiBuffer_.empty() && (emojiBuffer_.back() & 0xC0) == 0x80) {
+                        emojiBuffer_.pop_back();
+                    }
                 }
                 keyEvent.filterAndAccept();
             } else {

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -236,17 +236,16 @@ namespace fcitx {
     }
 
     void LotusState::handleEmojiMode(KeyEvent& keyEvent) {
-        const KeySym currentSym = keyEvent.rawKey().sym();
-        bool isCtrlBackspace = isBackspace(currentSym) &&
-                               (keyEvent.rawKey().states() & KeyState::Ctrl);
+        const KeySym currentSym      = keyEvent.rawKey().sym();
+        bool         isCtrlBackspace = isBackspace(currentSym) && (keyEvent.rawKey().states() & KeyState::Ctrl);
 
         if (keyEvent.key().hasModifier() && !isCtrlBackspace) {
             keyEvent.forward();
             return;
         }
 
-        auto         baseList   = ic_->inputPanel().candidateList();
-        auto         commonList = std::dynamic_pointer_cast<CommonCandidateList>(baseList);
+        auto baseList   = ic_->inputPanel().candidateList();
+        auto commonList = std::dynamic_pointer_cast<CommonCandidateList>(baseList);
         if (commonList && currentSym >= FcitxKey_1 && currentSym <= FcitxKey_9) {
             int offset      = currentSym - FcitxKey_1;
             int globalIndex = (commonList->currentPage() * commonList->pageSize()) + offset;


### PR DESCRIPTION
This pull request updates the emoji input handling logic in `LotusState` to better support the Ctrl+Backspace keyboard shortcut. The changes ensure that pressing Ctrl+Backspace clears the entire emoji buffer, while regular Backspace removes only the last character, including proper handling for multibyte UTF-8 characters.

**Emoji input handling improvements:**

* Modified the `handleEmojiMode` function in `src/lotus-state.cpp` to allow Ctrl+Backspace to bypass the usual modifier check, so that this shortcut is handled specially instead of being forwarded.
* Updated the Backspace handling logic so that pressing Ctrl+Backspace clears the entire `emojiBuffer_`, while a regular Backspace continues to remove only the last character (with correct support for multibyte UTF-8).