### PR TITLE
Introduce configurable Uinput Custom mode and update UI logic

### DIFF
--- a/server/lotus-server.cpp
+++ b/server/lotus-server.cpp
@@ -183,6 +183,7 @@ int main(int argc, char* argv[]) {
 
     int              addon_fd           = -1;
     int              pending_backspaces = 0;
+    int              current_inter_delay = 1;
 
     struct sigaction sa{};
     sa.sa_handler = signal_handler;
@@ -192,7 +193,7 @@ int main(int argc, char* argv[]) {
     sigaction(SIGINT, &sa, nullptr);
 
     while (g_running.load(std::memory_order_acquire)) {
-        int poll_timeout = (pending_backspaces > 0) ? 1 : -1;
+        int poll_timeout = (pending_backspaces > 0) ? current_inter_delay : -1;
         int ret          = poll(fds.data(), fds.size(), poll_timeout);
 
         if (ret < 0) {
@@ -244,14 +245,15 @@ int main(int argc, char* argv[]) {
 
         // handle connect from addon
         if (fds[KB_CLIENT_INDEX].fd >= 0 && (fds[KB_CLIENT_INDEX].revents & (POLLIN | POLLHUP | POLLERR)) != 0) {
-            int     count = 0;
-            ssize_t n     = recv(fds[KB_CLIENT_INDEX].fd, &count, sizeof(count), 0);
+            UinputMessage msg   = {0, 0};
+            ssize_t       n     = recv(fds[KB_CLIENT_INDEX].fd, &msg, sizeof(msg), 0);
             if (n <= 0) {
                 LotusLogger::instance().warn("Keyboard client disconnected or connection error");
                 close(fds[KB_CLIENT_INDEX].fd);
                 fds[KB_CLIENT_INDEX].fd = -1;
             } else {
-                pending_backspaces += count - 1;
+                pending_backspaces += msg.count - 1;
+                current_inter_delay = std::max(1, (int)msg.inter_delay_ms);
                 send_single_backspace();
             }
         }

--- a/server/lotus-server.h
+++ b/server/lotus-server.h
@@ -95,10 +95,15 @@ void close_restricted(int fd, void* user_data);
 extern const struct libinput_interface interface;
 
 /**
+ * @brief Message format for Uinput server.
+ */
+struct UinputMessage {
+    int32_t count;          ///< Number of backspaces to send
+    int32_t inter_delay_ms; ///< Delay between backspaces (ms)
+};
+
+/**
  * @brief Main entry point for the uinput server.
- * @param argc Argument count.
- * @param argv Argument vector.
- * @return Exit code (0 on success).
  */
 int main(int argc, char* argv[]);
 

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -41,13 +41,17 @@ SETTINGS_MAP = {
     SettingsCategory.GENERAL: {
         "HOTKEYS": ["ModeMenuKey"],
         "INPUT METHOD": ["InputMethod", "Mode", "OutputCharset"],
+        "UINPUT CUSTOM": ["UinputCustomPreDelay", "UinputCustomInterDelay", "UinputCustomDelay"],
     },
     SettingsCategory.APPEARANCE: {
         "THEME & ICONS": ["UseLotusIcons"],
     },
     SettingsCategory.TYPING: {
         "SPELLING & CORRECTIONS": ["SpellCheck", "AutoNonVnRestore", "DdFreeStyle"],
-        "TYPING OPTIONS": ["ModernStyle", "FreeMarking", "W2U", "FixUinputWithAck", "DoubleSpaceToPeriod", "AutoCapitalizeAfterPunctuation", "UinputCustomDelay"],
+        "TYPING OPTIONS": [
+            "ModernStyle", "FreeMarking", "W2U", "FixUinputWithAck", 
+            "DoubleSpaceToPeriod", "AutoCapitalizeAfterPunctuation"
+        ],
     },
     SettingsCategory.SHORTCUTS: {
         "SHORTCUTS": ["ModeMenuKey"],
@@ -161,7 +165,7 @@ class DynamicSettingsPage(QWidget):
                     elif type_str == "Boolean":
                         self._render_checkbox(item, card.content_layout)
                     elif type_str == "Integer":
-                        if k == "UinputCustomDelay":
+                        if k in ["UinputCustomDelay", "UinputCustomPreDelay", "UinputCustomInterDelay"]:
                             self._render_slider(item, card.content_layout)
                         else:
                             self._render_spinbox(item, card.content_layout)
@@ -282,7 +286,7 @@ class DynamicSettingsPage(QWidget):
         row_layout.addLayout(header_layout)
 
         slider = QSlider(Qt.Horizontal)
-        slider.setRange(0, 200)
+        slider.setRange(0, 100)
         slider.setValue(val)
         slider.setTickPosition(QSlider.TicksBothSides)
         slider.setTickInterval(20)

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -287,9 +287,11 @@ class DynamicSettingsPage(QWidget):
         slider.setTickPosition(QSlider.TicksBothSides)
         slider.setTickInterval(20)
         
-        slider.valueChanged.connect(
-            lambda v, k=key, l=val_label: (self.update_config(k, str(v)), l.setText(f"{v} ms"))
-        )
+        def on_value_changed(v):
+            self.update_config(key, str(v))
+            val_label.setText(f"{v} ms")
+
+        slider.valueChanged.connect(on_value_changed)
         
         row_layout.addWidget(slider)
         layout.addLayout(row_layout)

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -18,7 +18,10 @@ from PySide6.QtWidgets import (
     QButtonGroup,
     QGridLayout,
     QSizePolicy,
+    QSpinBox,
+    QSlider,
 )
+from PySide6.QtCore import Qt
 from ui.components import HotkeyCaptureWidget
 from core.dbus_handler import LotusDBusHandler
 from enum import Enum
@@ -44,7 +47,7 @@ SETTINGS_MAP = {
     },
     SettingsCategory.TYPING: {
         "SPELLING & CORRECTIONS": ["SpellCheck", "AutoNonVnRestore", "DdFreeStyle"],
-        "TYPING OPTIONS": ["ModernStyle", "FreeMarking", "W2U", "FixUinputWithAck", "DoubleSpaceToPeriod", "AutoCapitalizeAfterPunctuation"],
+        "TYPING OPTIONS": ["ModernStyle", "FreeMarking", "W2U", "FixUinputWithAck", "DoubleSpaceToPeriod", "AutoCapitalizeAfterPunctuation", "UinputCustomDelay"],
     },
     SettingsCategory.SHORTCUTS: {
         "SHORTCUTS": ["ModeMenuKey"],
@@ -157,6 +160,11 @@ class DynamicSettingsPage(QWidget):
                         self._render_combobox(item, card.content_layout)
                     elif type_str == "Boolean":
                         self._render_checkbox(item, card.content_layout)
+                    elif type_str == "Integer":
+                        if k == "UinputCustomDelay":
+                            self._render_slider(item, card.content_layout)
+                        else:
+                            self._render_spinbox(item, card.content_layout)
                 
                 if found_any:
                     self.container_layout.addWidget(card)
@@ -237,6 +245,53 @@ class DynamicSettingsPage(QWidget):
             lambda text, k=key: self.update_config(k, combo.currentData())
         )
         row_layout.addWidget(combo)
+        layout.addLayout(row_layout)
+
+    def _render_spinbox(self, item, layout):
+        key, type_str, label, default, annotations = item
+        val = int(self.current_values.get(key, default))
+
+        row_layout = QHBoxLayout()
+        row_layout.addWidget(QLabel(_(label)))
+        row_layout.addStretch()
+
+        spin = QSpinBox()
+        spin.setFixedWidth(200)
+        spin.setRange(0, 1000)
+        spin.setValue(val)
+        spin.setSuffix(" ms")
+
+        spin.valueChanged.connect(
+            lambda val, k=key: self.update_config(k, str(val))
+        )
+        row_layout.addWidget(spin)
+        layout.addLayout(row_layout)
+
+    def _render_slider(self, item, layout):
+        key, type_str, label, default, annotations = item
+        val = int(self.current_values.get(key, default))
+
+        row_layout = QVBoxLayout()
+        header_layout = QHBoxLayout()
+        header_layout.addWidget(QLabel(_(label)))
+        header_layout.addStretch()
+        
+        val_label = QLabel(f"{val} ms")
+        val_label.setObjectName("SliderValueLabel")
+        header_layout.addWidget(val_label)
+        row_layout.addLayout(header_layout)
+
+        slider = QSlider(Qt.Horizontal)
+        slider.setRange(0, 200)
+        slider.setValue(val)
+        slider.setTickPosition(QSlider.TicksBothSides)
+        slider.setTickInterval(20)
+        
+        slider.valueChanged.connect(
+            lambda v, k=key, l=val_label: (self.update_config(k, str(v)), l.setText(f"{v} ms"))
+        )
+        
+        row_layout.addWidget(slider)
         layout.addLayout(row_layout)
 
     def _render_radio_group(self, item, layout, columns=1):

--- a/settings-gui/ui/pages/mode_manager.py
+++ b/settings-gui/ui/pages/mode_manager.py
@@ -39,6 +39,7 @@ MODE_HARDCORE = 3
 MODE_SURROUNDING = 4
 MODE_PREEDIT = 5
 MODE_EMOJI = 6
+MODE_CUSTOM = 7
 MODE_DEFAULT = -1  # UI special value for "Use Global Default"
 
 MODE_INFO = {
@@ -50,6 +51,7 @@ MODE_INFO = {
     MODE_SURROUNDING: {"title": _("Surrounding Text"), "icon": "text-field"},
     MODE_PREEDIT: {"title": _("Preedit"), "icon": "text-field"},
     MODE_EMOJI: {"title": _("Emoji Picker"), "icon": "face-smile"},
+    MODE_CUSTOM: {"title": _("Uinput (Custom)"), "icon": "input-keyboard"},
 }
 
 
@@ -403,7 +405,7 @@ class ModeManagerPage(QWidget):
         self.combo_global_mode = QComboBox()
         global_modes = [
             MODE_OFF, MODE_SMOOTH, MODE_SLOW, MODE_HARDCORE,
-            MODE_SURROUNDING, MODE_PREEDIT, MODE_EMOJI
+            MODE_CUSTOM, MODE_SURROUNDING, MODE_PREEDIT, MODE_EMOJI
         ]
         for m in global_modes:
             self.combo_global_mode.addItem(MODE_INFO[m]["title"], MODE_INFO[m]["title"])
@@ -437,8 +439,9 @@ class ModeManagerPage(QWidget):
         grid_modes = [
             MODE_DEFAULT, MODE_OFF,
             MODE_SMOOTH, MODE_SLOW,
-            MODE_HARDCORE, MODE_SURROUNDING,
-            MODE_PREEDIT, MODE_EMOJI
+            MODE_HARDCORE, MODE_CUSTOM,
+            MODE_SURROUNDING, MODE_PREEDIT,
+            MODE_EMOJI
         ]
         for i, m in enumerate(grid_modes):
             card = ModeCard(m)
@@ -775,7 +778,7 @@ class ModeManagerPage(QWidget):
             with open(path, "w", encoding="utf-8") as f:
                 f.write("# Lotus Application Rules Table\n")
                 f.write("# Format: application_name<TAB>mode_id\n")
-                f.write("# Modes: 0=Off, 1=Uinput(Smooth), 2=Uinput(Slow), 3=Uinput(Hardcore), 4=Surrounding, 5=Preedit, 6=Emoji\n")
+                f.write("# Modes: 0=Off, 1=Uinput(Smooth), 2=Uinput(Slow), 3=Uinput(Hardcore), 4=Surrounding, 5=Preedit, 6=Emoji, 7=Uinput(Custom)\n")
                 for app, mode in sorted(self.app_rules.items()):
                     f.write(f"{app}\t{mode}\n")
             QMessageBox.information(

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -33,7 +33,8 @@ namespace fcitx {
         SurroundingText = 4,
         Preedit         = 5,
         Emoji           = 6,
-        NoMode          = 7,
+        UinputCustom    = 7,
+        NoMode          = 8,
     };
 
     /**
@@ -50,6 +51,7 @@ namespace fcitx {
             case LotusMode::UinputHC: return "Uinput (Hardcore)";
             case LotusMode::Emoji: return "Emoji Picker";
             case LotusMode::Smooth: return "Uinput (Smooth)";
+            case LotusMode::UinputCustom: return "Uinput (Custom)";
             default: return "";
         }
     }
@@ -68,6 +70,7 @@ namespace fcitx {
             {"Uinput (Hardcore)", LotusMode::UinputHC},
             {"Emoji Picker", LotusMode::Emoji},
             {"Uinput (Smooth)", LotusMode::Smooth},
+            {"Uinput (Custom)", LotusMode::UinputCustom},
         };
         auto it = modeMap.find(mode);
         return it != modeMap.end() ? it->second : LotusMode::NoMode;
@@ -135,7 +138,7 @@ namespace fcitx {
          * @brief Initializes with default mode list.
          */
         ModeListAnnotation() {
-            list_ = {"Uinput (Smooth)", "Uinput (Slow)", "Surrounding Text", "Preedit", "Uinput (Hardcore)", "OFF"};
+            list_ = {"Uinput (Smooth)", "Uinput (Slow)", "Uinput (Custom)", "Surrounding Text", "Preedit", "Uinput (Hardcore)", "OFF"};
         }
     };
 
@@ -211,6 +214,7 @@ namespace fcitx {
         Option<bool>    useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
         Option<bool>    enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
         Option<bool>    enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
+        Option<int>     uinputCustomDelay{this, "UinputCustomDelay", _("Uinput Custom Delay (ms)"), 20};
         SubConfigOption macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
         SubConfigOption customKeymap{this, "CustomKeymap", _("Custom Keymap"), "fcitx://config/addon/lotus/custom_keymap"};
         SubConfigOption appRules{this, "AppRules", _("App Rules"), "fcitx://config/addon/lotus/app_rules"}; KeyListOption modeMenuKey{

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -214,7 +214,9 @@ namespace fcitx {
         Option<bool>    useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
         Option<bool>    enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
         Option<bool>    enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
-        Option<int>     uinputCustomDelay{this, "UinputCustomDelay", _("Uinput Custom Delay (ms)"), 20};
+        Option<int>     uinputCustomPreDelay{this, "UinputCustomPreDelay", _("Uinput Custom Pre Delay (ms)"), 5};
+        Option<int>     uinputCustomInterDelay{this, "UinputCustomInterDelay", _("Uinput Custom Inter Delay (ms)"), 1};
+        Option<int>     uinputCustomDelay{this, "UinputCustomDelay", _("Uinput Custom Post Delay (ms)"), 20};
         SubConfigOption macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
         SubConfigOption customKeymap{this, "CustomKeymap", _("Custom Keymap"), "fcitx://config/addon/lotus/custom_keymap"};
         SubConfigOption appRules{this, "AppRules", _("App Rules"), "fcitx://config/addon/lotus/app_rules"}; KeyListOption modeMenuKey{

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -464,22 +464,26 @@ namespace fcitx {
                     break;
                 }
                 case FcitxKey_4: {
-                    selectedMode = LotusMode::SurroundingText;
+                    selectedMode = LotusMode::UinputCustom;
                     break;
                 }
                 case FcitxKey_q: {
-                    selectedMode = LotusMode::Preedit;
+                    selectedMode = LotusMode::SurroundingText;
                     break;
                 }
                 case FcitxKey_w: {
-                    selectedMode = LotusMode::Emoji;
+                    selectedMode = LotusMode::Preedit;
                     break;
                 }
                 case FcitxKey_e: {
-                    selectedMode = LotusMode::Off;
+                    selectedMode = LotusMode::Emoji;
                     break;
                 }
                 case FcitxKey_r: {
+                    selectedMode = LotusMode::Off;
+                    break;
+                }
+                case FcitxKey_d: {
                     selectedMode = modeStringToEnum(config_.mode.value());
                     break;
                 }
@@ -656,7 +660,7 @@ namespace fcitx {
             return;
 
         file << "# Lotus Per-App Configuration\n";
-        file << "# 0 = Off, 1 = Uinput (Smooth), 2 = Uinput (Slow), 3 = Uinput (Hardcore), 4 = Surrounding Text, 5 = Preedit, 6 = Emoji Picker\n";
+        file << "# 0 = Off, 1 = Uinput (Smooth), 2 = Uinput (Slow), 3 = Uinput (Hardcore), 4 = Uinput (Custom), 5 = Surrounding Text, 6 = Preedit, 7 = Emoji Picker\n";
         auto appRules = appRulesTables_.rules.value();
         for (const auto& pair : appRules) {
             if (!isStartsWith(pair.app.value(), "ctx_")) {
@@ -747,12 +751,12 @@ namespace fcitx {
         candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Smooth, _("[1] Uinput (Smooth)")), applyMode(LotusMode::Smooth)));
         candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Uinput, _("[2] Uinput (Slow)")), applyMode(LotusMode::Uinput)));
         candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::UinputHC, _("[3] Uinput (Hardcore)")), applyMode(LotusMode::UinputHC)));
-        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::SurroundingText, _("[4] Surrounding Text")), applyMode(LotusMode::SurroundingText)));
-        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Preedit, _("[q] Preedit")), applyMode(LotusMode::Preedit)));
-        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Emoji, _("[w] Emoji Picker")), applyMode(LotusMode::Emoji)));
-        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Off, _("[e] OFF")), applyMode(LotusMode::Off)));
-
-        candidateList->append(std::make_unique<AppModeCandidateWord>(Text(_("[r] Default Typing")), [this, cleanup](InputContext* ic) {
+        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::UinputCustom, _("[4] Uinput (Custom)")), applyMode(LotusMode::UinputCustom)));
+        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::SurroundingText, _("[q] Surrounding Text")), applyMode(LotusMode::SurroundingText)));
+        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Preedit, _("[w] Preedit")), applyMode(LotusMode::Preedit)));
+        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Emoji, _("[e] Emoji Picker")), applyMode(LotusMode::Emoji)));
+        candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Off, _("[r] OFF")), applyMode(LotusMode::Off)));
+        candidateList->append(std::make_unique<AppModeCandidateWord>(Text(_("[d] Default Typing")), [this, cleanup](InputContext* ic) {
             setMode(modeStringToEnum(config_.mode.value()), ic);
             cleanup(ic);
         }));
@@ -778,11 +782,12 @@ namespace fcitx {
             case LotusMode::Smooth: selectedIndex = 1; break;
             case LotusMode::Uinput: selectedIndex = 2; break;
             case LotusMode::UinputHC: selectedIndex = 3; break;
-            case LotusMode::SurroundingText: selectedIndex = 4; break;
-            case LotusMode::Preedit: selectedIndex = 5; break;
-            case LotusMode::Emoji: selectedIndex = 6; break;
-            case LotusMode::Off: selectedIndex = 7; break;
-            default: selectedIndex = 1; break;
+            case LotusMode::UinputCustom: selectedIndex = 4; break;
+            case LotusMode::SurroundingText: selectedIndex = 5; break;
+            case LotusMode::Preedit: selectedIndex = 6; break;
+            case LotusMode::Emoji: selectedIndex = 7; break;
+            case LotusMode::Off: selectedIndex = 8; break;
+            default: selectedIndex = 9; break;
         }
         candidateList->setGlobalCursorIndex(selectedIndex);
 

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -660,7 +660,7 @@ namespace fcitx {
             return;
 
         file << "# Lotus Per-App Configuration\n";
-        file << "# 0 = Off, 1 = Uinput (Smooth), 2 = Uinput (Slow), 3 = Uinput (Hardcore), 4 = Uinput (Custom), 5 = Surrounding Text, 6 = Preedit, 7 = Emoji Picker\n";
+        file << "# 0 = Off, 1 = Uinput (Smooth), 2 = Uinput (Slow), 3 = Uinput (Hardcore), 4 = Surrounding Text, 5 = Preedit, 6 = Emoji Picker, 7 = Uinput (Custom)\n";
         auto appRules = appRulesTables_.rules.value();
         for (const auto& pair : appRules) {
             if (!isStartsWith(pair.app.value(), "ctx_")) {

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -483,10 +483,6 @@ namespace fcitx {
                     selectedMode = LotusMode::Off;
                     break;
                 }
-                case FcitxKey_d: {
-                    selectedMode = modeStringToEnum(config_.mode.value());
-                    break;
-                }
                 case FcitxKey_Escape: {
                     selectionMade = true;
                     break;
@@ -756,10 +752,6 @@ namespace fcitx {
         candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Preedit, _("[w] Preedit")), applyMode(LotusMode::Preedit)));
         candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Emoji, _("[e] Emoji Picker")), applyMode(LotusMode::Emoji)));
         candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(LotusMode::Off, _("[r] OFF")), applyMode(LotusMode::Off)));
-        candidateList->append(std::make_unique<AppModeCandidateWord>(Text(_("[d] Default Typing")), [this, cleanup](InputContext* ic) {
-            setMode(modeStringToEnum(config_.mode.value()), ic);
-            cleanup(ic);
-        }));
 
         {
             const auto& kl = *config_.modeMenuKey;
@@ -787,7 +779,7 @@ namespace fcitx {
             case LotusMode::Preedit: selectedIndex = 6; break;
             case LotusMode::Emoji: selectedIndex = 7; break;
             case LotusMode::Off: selectedIndex = 8; break;
-            default: selectedIndex = 9; break;
+            default: selectedIndex = 1; break;
         }
         candidateList->setGlobalCursorIndex(selectedIndex);
 

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -944,7 +944,14 @@ namespace fcitx {
             if (isBackspace(currentSym)) {
                 if (realtextLen > 0)
                     realtextLen -= 1;
-                if (handleUInputKeyPress(keyEvent, currentSym, (realMode == LotusMode::Smooth) ? 5 : 20)) {
+                int sleepTime = 20;
+                if (realMode == LotusMode::Smooth) {
+                    sleepTime = 5;
+                } else if (realMode == LotusMode::UinputCustom) {
+                    sleepTime = engine_->config().uinputCustomDelay.value();
+                }
+
+                if (handleUInputKeyPress(keyEvent, currentSym, sleepTime)) {
                     return;
                 }
             } else {
@@ -974,6 +981,7 @@ namespace fcitx {
 
         switch (realMode) {
             case LotusMode::Uinput:
+            case LotusMode::UinputCustom:
             case LotusMode::Smooth: {
                 handleUinputMode(keyEvent, currentSym, true);
                 break;
@@ -1037,6 +1045,7 @@ namespace fcitx {
             case LotusMode::SurroundingText:
             case LotusMode::Uinput:
             case LotusMode::UinputHC:
+            case LotusMode::UinputCustom:
             case LotusMode::Smooth: {
                 ic_->inputPanel().reset();
                 break;
@@ -1069,6 +1078,7 @@ namespace fcitx {
             }
             case LotusMode::Uinput:
             case LotusMode::UinputHC:
+            case LotusMode::UinputCustom:
             case LotusMode::Smooth: {
                 if (lotusEngine_) {
                     UniqueCPtr<char> preedit(EnginePullPreedit(lotusEngine_.handle()));

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -107,13 +107,14 @@ namespace fcitx {
         return connect_uinput_server() ? uinput_client_fd_ : -1;
     }
 
-    void LotusState::send_backspace_uinput(int count) const {
+    void LotusState::send_backspace_uinput(int count, int interDelay) const {
         if (uinput_client_fd_ < 0 && !connect_uinput_server()) {
             LOTUS_ERROR("Cannot send backspace since cannot connect to uinput server");
             return;
         }
 
-        ssize_t n = send(uinput_client_fd_, &count, sizeof(count), MSG_NOSIGNAL);
+        UinputMessage msg = {static_cast<int32_t>(count), static_cast<int32_t>(interDelay)};
+        ssize_t n = send(uinput_client_fd_, &msg, sizeof(msg), MSG_NOSIGNAL);
 
         if (n < 0) {
             LOTUS_WARN("Failed to send backspace: " + std::string(strerror(errno)));
@@ -121,13 +122,13 @@ namespace fcitx {
             uinput_client_fd_ = -1;
             if (connect_uinput_server()) {
                 LOTUS_INFO("Reconnected to uinput server successfully");
-                send(uinput_client_fd_, &count, sizeof(count), MSG_NOSIGNAL);
+                send(uinput_client_fd_, &msg, sizeof(msg), MSG_NOSIGNAL);
             }
         }
 
         if (waitAck_) {
             LOTUS_INFO("Waiting for ack");
-            std::this_thread::sleep_for(std::chrono::milliseconds(count * 5));
+            std::this_thread::sleep_for(std::chrono::milliseconds(count * (interDelay + 2)));
         }
     }
 
@@ -486,8 +487,20 @@ namespace fcitx {
         replacement_start_ms_.store(now_ms(), std::memory_order_release);
         is_deleting_.store(true, std::memory_order_release);
         monitor_cv.notify_one();
-        send_backspace_uinput(expected_backspaces_);
-        LOTUS_INFO("Send " + std::to_string(expected_backspaces_) + " backspaces");
+        
+        int preDelay = 5;
+        int interDelay = 1;
+        if (realMode == LotusMode::UinputCustom) {
+            preDelay = *engine_->config().uinputCustomPreDelay;
+            interDelay = *engine_->config().uinputCustomInterDelay;
+        }
+        
+        if (preDelay > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(preDelay));
+        }
+        
+        send_backspace_uinput(expected_backspaces_, interDelay);
+        LOTUS_INFO("Send " + std::to_string(expected_backspaces_) + " backspaces (interDelay: " + std::to_string(interDelay) + "ms)");
     }
 
     void LotusState::checkForwardSpecialKey(KeyEvent& keyEvent, KeySym& currentSym) {

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -120,8 +120,9 @@ namespace fcitx {
         /**
          * @brief Sends backspace key events via uinput.
          * @param count Number of backspaces to send.
+         * @param interDelay Delay between backspaces (ms).
          */
-        void send_backspace_uinput(int count) const;
+        void send_backspace_uinput(int count, int interDelay) const;
 
         /**
          * @brief Replays buffer content to the engine.

--- a/src/lotus-utils.h
+++ b/src/lotus-utils.h
@@ -102,4 +102,12 @@ struct KeyEntry {
     uint32_t state; ///< Key state (modifiers)
 };
 
+/**
+ * @brief Message format for Uinput server.
+ */
+struct UinputMessage {
+    int32_t count;          ///< Number of backspaces to send
+    int32_t inter_delay_ms; ///< Delay between backspaces (ms)
+};
+
 #endif // _FCITX5_LOTUS_UTILS_H_


### PR DESCRIPTION
This pull request introduces a new "Uinput (Custom)" typing mode to the Lotus input method, allowing users to set a custom delay for simulated keypresses. The implementation includes both backend logic and frontend GUI changes, providing users with a slider or spinbox to adjust the delay. Additionally, the mode selection UI and per-app configuration have been updated to support and display this new mode.

**New "Uinput (Custom)" Mode and Configurability:**

* Added a new `LotusMode::UinputCustom` enum value and integrated it throughout the mode selection logic, candidate list, and per-app configuration comments/documentation. [[1]](diffhunk://#diff-0747c15b20f347a2c0096feec91525cd3d73f87124df97670cd41fa00ddf26afL36-R37) [[2]](diffhunk://#diff-0747c15b20f347a2c0096feec91525cd3d73f87124df97670cd41fa00ddf26afR54) [[3]](diffhunk://#diff-0747c15b20f347a2c0096feec91525cd3d73f87124df97670cd41fa00ddf26afR73) [[4]](diffhunk://#diff-0747c15b20f347a2c0096feec91525cd3d73f87124df97670cd41fa00ddf26afL138-R141) [[5]](diffhunk://#diff-749a603ffe54ea4ec56acbe9e977825645b3196fda3554da94a15ec156717b8eL659-R663) [[6]](diffhunk://#diff-749a603ffe54ea4ec56acbe9e977825645b3196fda3554da94a15ec156717b8eL750-R759) [[7]](diffhunk://#diff-749a603ffe54ea4ec56acbe9e977825645b3196fda3554da94a15ec156717b8eL781-R790)
* Added a new configuration option `UinputCustomDelay` (in milliseconds) to the backend, which is used to control the keypress delay in the custom mode. [[1]](diffhunk://#diff-0747c15b20f347a2c0096feec91525cd3d73f87124df97670cd41fa00ddf26afR217) [[2]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67L947-R954)

**Frontend/GUI Enhancements:**

* Updated the settings GUI to include "UinputCustomDelay" under typing options, and render it as a slider or spinbox for user adjustment. [[1]](diffhunk://#diff-20f58274253cf8ae57a9bd94d0281a8f2254f81cff06b2fe5f987f09bbfc99f7L47-R50) [[2]](diffhunk://#diff-20f58274253cf8ae57a9bd94d0281a8f2254f81cff06b2fe5f987f09bbfc99f7R163-R167) [[3]](diffhunk://#diff-20f58274253cf8ae57a9bd94d0281a8f2254f81cff06b2fe5f987f09bbfc99f7R250-R296) [[4]](diffhunk://#diff-20f58274253cf8ae57a9bd94d0281a8f2254f81cff06b2fe5f987f09bbfc99f7R21-R24)

**Engine and State Handling:**

* Updated key event handling and mode switching logic to support the new custom mode, ensuring the correct delay is applied and the mode is properly integrated with existing logic. [[1]](diffhunk://#diff-749a603ffe54ea4ec56acbe9e977825645b3196fda3554da94a15ec156717b8eL467-R486) [[2]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67R984) [[3]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67R1048) [[4]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67R1081)