### PR TITLE
Add backup and restore functionality to settings GUI

### DIFF
--- a/settings-gui/ui/main_window.py
+++ b/settings-gui/ui/main_window.py
@@ -30,6 +30,7 @@ from ui.pages.dict_editor import DictEditorPage
 from ui.pages.keymap_editor import KeymapEditorPage
 from ui.pages.about import AboutPage
 from ui.pages.mode_manager import ModeManagerPage
+from ui.pages.backup import BackupPage
 import os
 
 
@@ -201,6 +202,11 @@ class LotusSettingsWindow(QMainWindow):
             DynamicSettingsPage(
                 self.dbus_handler, category=SettingsCategory.APPEARANCE
             ),
+        )
+        self._add_page(
+            _("Backup"),
+            "document-save-as",
+            BackupPage(self.dbus_handler),
         )
 
         # Bottom section

--- a/settings-gui/ui/pages/backup.py
+++ b/settings-gui/ui/pages/backup.py
@@ -218,7 +218,6 @@ class BackupPage(QWidget):
 
             self.restore_group.setVisible(True)
             self.btn_restore.setVisible(True)
-            self.btn_restore.setVisible(True)
 
         except Exception as e:
             QMessageBox.critical(self, _("Error"), _("Failed to open backup file:\n") + str(e))

--- a/settings-gui/ui/pages/backup.py
+++ b/settings-gui/ui/pages/backup.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+Backup and Restore page for Lotus settings.
+Supports ZIP-based backups and selective export/import.
+"""
+
+import os
+import json
+import zipfile
+from datetime import datetime
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QFileDialog,
+    QMessageBox,
+    QFrame,
+    QScrollArea,
+    QCheckBox,
+    QGroupBox,
+)
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
+from i18n import _
+from core.dbus_handler import LotusDBusHandler
+from ui.pages.dynamic_settings import CardWidget
+
+
+class BackupPage(QWidget):
+    def __init__(self, dbus_handler: LotusDBusHandler, parent=None):
+        super().__init__(parent)
+        self.dbus = dbus_handler
+        self.restore_data = None  # Stores data from opened backup for selective restore
+        self._setup_ui()
+
+    def _setup_ui(self):
+        root_layout = QVBoxLayout(self)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.NoFrame)
+
+        content_widget = QWidget()
+        layout = QVBoxLayout(content_widget)
+        layout.setContentsMargins(30, 20, 30, 20)
+        layout.setSpacing(20)
+
+        title = QLabel(_("Backup & Restore"))
+        title.setObjectName("CategoryTitle")
+        layout.addWidget(title)
+
+        # Single Card for Export / Import
+        self.main_card = CardWidget(_("Export/Import Settings"))
+        
+        self.import_desc = QLabel(
+            _(
+                "Save your configurations to a ZIP file, or restore them from a .lotusbak file. Select what you want to include:"
+            )
+        )
+        self.import_desc.setWordWrap(True)
+        self.import_desc.setStyleSheet("color: gray; font-size: 13px;")
+        self.main_card.content_layout.addWidget(self.import_desc)
+
+        # Shared Checkboxes
+        self.checkboxes = {
+            "config": QCheckBox(_("Main Settings")),
+            "macros": QCheckBox(_("Macros")),
+            "keymaps": QCheckBox(_("Custom Keymaps")),
+            "rules": QCheckBox(_("Application Rules")),
+            "dictionary": QCheckBox(_("Custom Dictionary")),
+        }
+        for cb in self.checkboxes.values():
+            cb.setChecked(True)
+            self.main_card.content_layout.addWidget(cb)
+
+        # Buttons (Horizontal layout)
+        btn_layout = QHBoxLayout()
+        btn_layout.setSpacing(10)
+        
+        self.btn_export = QPushButton(QIcon.fromTheme("document-save-as"), _("Export Backup..."))
+        self.btn_export.clicked.connect(self.do_export)
+        self.btn_export.setMinimumHeight(40)
+        
+        self.btn_import = QPushButton(QIcon.fromTheme("document-open"), _("Import Backup..."))
+        self.btn_import.clicked.connect(self.on_select_import_file)
+        self.btn_import.setMinimumHeight(40)
+        
+        btn_layout.addWidget(self.btn_export)
+        btn_layout.addWidget(self.btn_import)
+        self.main_card.content_layout.addLayout(btn_layout)
+
+        # Restore Confirmation (hidden initially)
+        self.restore_group = QGroupBox(_("Items found in backup:"))
+        self.restore_group_layout = QVBoxLayout(self.restore_group)
+        self.restore_group.setVisible(False)
+        self.main_card.content_layout.addWidget(self.restore_group)
+
+        self.btn_restore = QPushButton(QIcon.fromTheme("system-reboot"), _("Restore Selected Now"))
+        self.btn_restore.clicked.connect(self.on_restore_selected)
+        self.btn_restore.setMinimumHeight(40)
+        self.btn_restore.setVisible(False)
+        self.btn_restore.setStyleSheet("font-weight: bold;")
+        self.main_card.content_layout.addWidget(self.btn_restore)
+        
+        layout.addWidget(self.main_card)
+
+        layout.addStretch()
+        scroll.setWidget(content_widget)
+        root_layout.addWidget(scroll)
+
+    def _get_local_dict_path(self) -> str:
+        xdg_data_home = os.environ.get(
+            "XDG_DATA_HOME", os.path.expanduser("~/.local/share")
+        )
+        return os.path.join(xdg_data_home, "fcitx5/lotus/vietnamese.cm.dict")
+
+    def do_export(self):
+        """Creates a ZIP backup of selected components."""
+        selected = {k: cb.isChecked() for k, cb in self.checkboxes.items()}
+        if not any(selected.values()):
+            QMessageBox.warning(self, _("Warning"), _("Please select at least one item to export."))
+            return
+
+        default_filename = f"lotus-backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}.lotusbak"
+        path, _filter = QFileDialog.getSaveFileName(
+            self,
+            _("Export Backup"),
+            os.path.join(os.path.expanduser("~"), default_filename),
+            _("Lotus Backup (*.lotusbak *.zip);;All Files (*)"),
+        )
+        if not path:
+            return
+
+        try:
+            with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+                # Meta info
+                meta = {
+                    "version": 1,
+                    "timestamp": datetime.now().isoformat(),
+                    "components": [k for k, v in selected.items() if v]
+                }
+                zipf.writestr("meta.json", json.dumps(meta, indent=2))
+
+                if selected["config"]:
+                    config_data = self.dbus.get_config().get("values", {})
+                    zipf.writestr("config.json", json.dumps(config_data, indent=2))
+
+                if selected["macros"]:
+                    macros = self.dbus.get_sub_config_list("lotus-macro", "Macro")
+                    zipf.writestr("macros.json", json.dumps(macros, indent=2))
+
+                if selected["keymaps"]:
+                    keymaps = self.dbus.get_sub_config_list("custom_keymap", "CustomKeymap")
+                    zipf.writestr("keymaps.json", json.dumps(keymaps, indent=2))
+
+                if selected["rules"]:
+                    rules = self.dbus.get_sub_config_list("app_rules", "Rules")
+                    zipf.writestr("rules.json", json.dumps(rules, indent=2))
+
+                if selected["dictionary"]:
+                    dict_path = self._get_local_dict_path()
+                    if os.path.exists(dict_path):
+                        zipf.write(dict_path, "dictionary.txt")
+
+            QMessageBox.information(self, _("Success"), _("Backup exported successfully to:\n") + path)
+
+        except Exception as e:
+            QMessageBox.critical(self, _("Error"), _("Failed to export backup:\n") + str(e))
+
+    def on_select_import_file(self):
+        """Opens a ZIP backup and shows available components for restore."""
+        path, _filter = QFileDialog.getOpenFileName(
+            self,
+            _("Select Backup File"),
+            os.path.expanduser("~"),
+            _("Lotus Backup (*.lotusbak *.zip);;All Files (*)"),
+        )
+        if not path:
+            return
+
+        try:
+            # Re-init UI for restore
+            for i in reversed(range(self.restore_group_layout.count())):
+                widget = self.restore_group_layout.itemAt(i).widget()
+                if widget:
+                    widget.deleteLater()
+
+            self.restore_checkboxes = {}
+            self.restore_data = {"zip_path": path}
+
+            with zipfile.ZipFile(path, 'r') as zipf:
+                namelist = zipf.namelist()
+                
+                options = [
+                    ("config.json", "config", _("Main Settings")),
+                    ("macros.json", "macros", _("Macros")),
+                    ("keymaps.json", "keymaps", _("Custom Keymaps")),
+                    ("rules.json", "rules", _("Application Rules")),
+                    ("dictionary.txt", "dictionary", _("Custom Dictionary")),
+                ]
+
+                found_any = False
+                for filename, key, label in options:
+                    if filename in namelist:
+                        cb = QCheckBox(label)
+                        cb.setChecked(True)
+                        self.restore_checkboxes[key] = cb
+                        self.restore_group_layout.addWidget(cb)
+                        found_any = True
+
+                if not found_any:
+                    raise ValueError(_("Invalid backup file: No recognizable components found."))
+
+            self.restore_group.setVisible(True)
+            self.btn_restore.setVisible(True)
+            self.btn_restore.setVisible(True)
+
+        except Exception as e:
+            QMessageBox.critical(self, _("Error"), _("Failed to open backup file:\n") + str(e))
+
+    def on_restore_selected(self):
+        """Applies selected components from the ZIP backup."""
+        if not self.restore_data or "zip_path" not in self.restore_data:
+            return
+
+        selected_keys = [k for k, cb in self.restore_checkboxes.items() if cb.isChecked()]
+        if not selected_keys:
+            QMessageBox.warning(self, _("Warning"), _("Please select at least one item to restore."))
+            return
+
+        reply = QMessageBox.warning(
+            self,
+            _("Confirm Restore"),
+            _(
+                "Are you sure you want to restore the selected components? This will overwrite your current configuration."
+            ),
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            return
+
+        try:
+            with zipfile.ZipFile(self.restore_data["zip_path"], 'r') as zipf:
+                if "config" in selected_keys:
+                    data = json.loads(zipf.read("config.json"))
+                    self.dbus.set_config(data)
+
+                if "macros" in selected_keys:
+                    data = json.loads(zipf.read("macros.json"))
+                    self.dbus.set_sub_config_list("lotus-macro", "Macro", data)
+
+                if "keymaps" in selected_keys:
+                    data = json.loads(zipf.read("keymaps.json"))
+                    self.dbus.set_sub_config_list("custom_keymap", "CustomKeymap", data)
+
+                if "rules" in selected_keys:
+                    data = json.loads(zipf.read("rules.json"))
+                    self.dbus.set_sub_config_list("app_rules", "Rules", data)
+
+                if "dictionary" in selected_keys:
+                    dict_path = self._get_local_dict_path()
+                    os.makedirs(os.path.dirname(dict_path), exist_ok=True)
+                    with open(dict_path, "wb") as f:
+                        f.write(zipf.read("dictionary.txt"))
+
+            QMessageBox.information(
+                self,
+                _("Success"),
+                _(
+                    "Selected components restored successfully. Some changes may require restarting Fcitx5."
+                ),
+            )
+
+            # Trigger UI reload
+            main_win = self.window()
+            if hasattr(main_win, "on_cancel"):
+                main_win.on_cancel()
+
+            # Reset Restore UI
+            self.restore_group.setVisible(False)
+            self.btn_restore.setVisible(False)
+            self.restore_data = None
+
+        except Exception as e:
+            QMessageBox.critical(self, _("Error"), _("Failed to restore backup:\n") + str(e))

--- a/settings-gui/ui/pages/backup.py
+++ b/settings-gui/ui/pages/backup.py
@@ -3,12 +3,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """
 Backup and Restore page for Lotus settings.
-Supports ZIP-based backups and selective export/import.
+Supports JSON-based backups and selective export/import.
 """
 
 import os
 import json
-import zipfile
 from datetime import datetime
 from PySide6.QtWidgets import (
     QWidget,
@@ -56,10 +55,10 @@ class BackupPage(QWidget):
 
         # Single Card for Export / Import
         self.main_card = CardWidget(_("Export/Import Settings"))
-        
+
         self.import_desc = QLabel(
             _(
-                "Save your configurations to a ZIP file, or restore them from a .lotusbak file. Select what you want to include:"
+                "Save your configurations to a JSON file, or restore them from a .lotusbak file. Select what you want to include:"
             )
         )
         self.import_desc.setWordWrap(True)
@@ -81,15 +80,19 @@ class BackupPage(QWidget):
         # Buttons (Horizontal layout)
         btn_layout = QHBoxLayout()
         btn_layout.setSpacing(10)
-        
-        self.btn_export = QPushButton(QIcon.fromTheme("document-save-as"), _("Export Backup..."))
+
+        self.btn_export = QPushButton(
+            QIcon.fromTheme("document-save-as"), _("Export Backup...")
+        )
         self.btn_export.clicked.connect(self.do_export)
         self.btn_export.setMinimumHeight(40)
-        
-        self.btn_import = QPushButton(QIcon.fromTheme("document-open"), _("Import Backup..."))
+
+        self.btn_import = QPushButton(
+            QIcon.fromTheme("document-open"), _("Import Backup...")
+        )
         self.btn_import.clicked.connect(self.on_select_import_file)
         self.btn_import.setMinimumHeight(40)
-        
+
         btn_layout.addWidget(self.btn_export)
         btn_layout.addWidget(self.btn_import)
         self.main_card.content_layout.addLayout(btn_layout)
@@ -100,13 +103,15 @@ class BackupPage(QWidget):
         self.restore_group.setVisible(False)
         self.main_card.content_layout.addWidget(self.restore_group)
 
-        self.btn_restore = QPushButton(QIcon.fromTheme("system-reboot"), _("Restore Selected Now"))
+        self.btn_restore = QPushButton(
+            QIcon.fromTheme("system-reboot"), _("Restore Selected Now")
+        )
         self.btn_restore.clicked.connect(self.on_restore_selected)
         self.btn_restore.setMinimumHeight(40)
         self.btn_restore.setVisible(False)
         self.btn_restore.setStyleSheet("font-weight: bold;")
         self.main_card.content_layout.addWidget(self.btn_restore)
-        
+
         layout.addWidget(self.main_card)
 
         layout.addStretch()
@@ -120,65 +125,76 @@ class BackupPage(QWidget):
         return os.path.join(xdg_data_home, "fcitx5/lotus/vietnamese.cm.dict")
 
     def do_export(self):
-        """Creates a ZIP backup of selected components."""
+        """Creates a JSON backup of selected components."""
         selected = {k: cb.isChecked() for k, cb in self.checkboxes.items()}
         if not any(selected.values()):
-            QMessageBox.warning(self, _("Warning"), _("Please select at least one item to export."))
+            QMessageBox.warning(
+                self, _("Warning"), _("Please select at least one item to export.")
+            )
             return
 
-        default_filename = f"lotus-backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}.lotusbak"
+        default_filename = (
+            f"lotus-backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}.lotusbak"
+        )
         path, _filter = QFileDialog.getSaveFileName(
             self,
             _("Export Backup"),
             os.path.join(os.path.expanduser("~"), default_filename),
-            _("Lotus Backup (*.lotusbak *.zip);;All Files (*)"),
+            _("Lotus Backup (*.lotusbak);;All Files (*)"),
         )
         if not path:
             return
 
         try:
-            with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-                # Meta info
-                meta = {
+            backup = {
+                "meta": {
                     "version": 1,
                     "timestamp": datetime.now().isoformat(),
-                    "components": [k for k, v in selected.items() if v]
+                    "components": [k for k, v in selected.items() if v],
                 }
-                zipf.writestr("meta.json", json.dumps(meta, indent=2))
+            }
 
-                if selected["config"]:
-                    config_data = self.dbus.get_config().get("values", {})
-                    zipf.writestr("config.json", json.dumps(config_data, indent=2))
+            if selected["config"]:
+                config_data = self.dbus.get_config().get("values", {})
+                backup["config"] = config_data
 
-                if selected["macros"]:
-                    macros = self.dbus.get_sub_config_list("lotus-macro", "Macro")
-                    zipf.writestr("macros.json", json.dumps(macros, indent=2))
+            if selected["macros"]:
+                macros = self.dbus.get_sub_config_list("lotus-macro", "Macro")
+                backup["macros"] = macros
 
-                if selected["keymaps"]:
-                    keymaps = self.dbus.get_sub_config_list("custom_keymap", "CustomKeymap")
-                    zipf.writestr("keymaps.json", json.dumps(keymaps, indent=2))
+            if selected["keymaps"]:
+                keymaps = self.dbus.get_sub_config_list("custom_keymap", "CustomKeymap")
+                backup["keymaps"] = keymaps
 
-                if selected["rules"]:
-                    rules = self.dbus.get_sub_config_list("app_rules", "Rules")
-                    zipf.writestr("rules.json", json.dumps(rules, indent=2))
+            if selected["rules"]:
+                rules = self.dbus.get_sub_config_list("app_rules", "Rules")
+                backup["rules"] = rules
 
-                if selected["dictionary"]:
-                    dict_path = self._get_local_dict_path()
-                    if os.path.exists(dict_path):
-                        zipf.write(dict_path, "dictionary.txt")
+            if selected["dictionary"]:
+                dict_path = self._get_local_dict_path()
+                if os.path.exists(dict_path):
+                    with open(dict_path, "r", encoding="utf-8") as f:
+                        backup["dictionary"] = f.read()
 
-            QMessageBox.information(self, _("Success"), _("Backup exported successfully to:\n") + path)
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(backup, f, indent=2, ensure_ascii=False)
+
+            QMessageBox.information(
+                self, _("Success"), _("Backup exported successfully to:\n") + path
+            )
 
         except Exception as e:
-            QMessageBox.critical(self, _("Error"), _("Failed to export backup:\n") + str(e))
+            QMessageBox.critical(
+                self, _("Error"), _("Failed to export backup:\n") + str(e)
+            )
 
     def on_select_import_file(self):
-        """Opens a ZIP backup and shows available components for restore."""
+        """Opens a JSON backup and shows available components for restore."""
         path, _filter = QFileDialog.getOpenFileName(
             self,
             _("Select Backup File"),
             os.path.expanduser("~"),
-            _("Lotus Backup (*.lotusbak *.zip);;All Files (*)"),
+            _("Lotus Backup (*.lotusbak);;All Files (*)"),
         )
         if not path:
             return
@@ -191,45 +207,53 @@ class BackupPage(QWidget):
                     widget.deleteLater()
 
             self.restore_checkboxes = {}
-            self.restore_data = {"zip_path": path}
+            self.restore_data = {"json_path": path}
 
-            with zipfile.ZipFile(path, 'r') as zipf:
-                namelist = zipf.namelist()
-                
-                options = [
-                    ("config.json", "config", _("Main Settings")),
-                    ("macros.json", "macros", _("Macros")),
-                    ("keymaps.json", "keymaps", _("Custom Keymaps")),
-                    ("rules.json", "rules", _("Application Rules")),
-                    ("dictionary.txt", "dictionary", _("Custom Dictionary")),
-                ]
+            with open(path, "r", encoding="utf-8") as f:
+                backup = json.load(f)
 
-                found_any = False
-                for filename, key, label in options:
-                    if filename in namelist:
-                        cb = QCheckBox(label)
-                        cb.setChecked(True)
-                        self.restore_checkboxes[key] = cb
-                        self.restore_group_layout.addWidget(cb)
-                        found_any = True
+            options = [
+                ("config", _("Main Settings")),
+                ("macros", _("Macros")),
+                ("keymaps", _("Custom Keymaps")),
+                ("rules", _("Application Rules")),
+                ("dictionary", _("Custom Dictionary")),
+            ]
 
-                if not found_any:
-                    raise ValueError(_("Invalid backup file: No recognizable components found."))
+            found_any = False
+            for key, label in options:
+                if key in backup:
+                    cb = QCheckBox(label)
+                    cb.setChecked(True)
+                    self.restore_checkboxes[key] = cb
+                    self.restore_group_layout.addWidget(cb)
+                    found_any = True
+
+            if not found_any:
+                raise ValueError(
+                    _("Invalid backup file: No recognizable components found.")
+                )
 
             self.restore_group.setVisible(True)
             self.btn_restore.setVisible(True)
 
         except Exception as e:
-            QMessageBox.critical(self, _("Error"), _("Failed to open backup file:\n") + str(e))
+            QMessageBox.critical(
+                self, _("Error"), _("Failed to open backup file:\n") + str(e)
+            )
 
     def on_restore_selected(self):
-        """Applies selected components from the ZIP backup."""
-        if not self.restore_data or "zip_path" not in self.restore_data:
+        """Applies selected components from the JSON backup."""
+        if not self.restore_data or "json_path" not in self.restore_data:
             return
 
-        selected_keys = [k for k, cb in self.restore_checkboxes.items() if cb.isChecked()]
+        selected_keys = [
+            k for k, cb in self.restore_checkboxes.items() if cb.isChecked()
+        ]
         if not selected_keys:
-            QMessageBox.warning(self, _("Warning"), _("Please select at least one item to restore."))
+            QMessageBox.warning(
+                self, _("Warning"), _("Please select at least one item to restore.")
+            )
             return
 
         reply = QMessageBox.warning(
@@ -244,28 +268,28 @@ class BackupPage(QWidget):
             return
 
         try:
-            with zipfile.ZipFile(self.restore_data["zip_path"], 'r') as zipf:
-                if "config" in selected_keys:
-                    data = json.loads(zipf.read("config.json"))
-                    self.dbus.set_config(data)
+            with open(self.restore_data["json_path"], "r", encoding="utf-8") as f:
+                backup = json.load(f)
 
-                if "macros" in selected_keys:
-                    data = json.loads(zipf.read("macros.json"))
-                    self.dbus.set_sub_config_list("lotus-macro", "Macro", data)
+            if "config" in selected_keys and "config" in backup:
+                self.dbus.set_config(backup["config"])
 
-                if "keymaps" in selected_keys:
-                    data = json.loads(zipf.read("keymaps.json"))
-                    self.dbus.set_sub_config_list("custom_keymap", "CustomKeymap", data)
+            if "macros" in selected_keys and "macros" in backup:
+                self.dbus.set_sub_config_list("lotus-macro", "Macro", backup["macros"])
 
-                if "rules" in selected_keys:
-                    data = json.loads(zipf.read("rules.json"))
-                    self.dbus.set_sub_config_list("app_rules", "Rules", data)
+            if "keymaps" in selected_keys and "keymaps" in backup:
+                self.dbus.set_sub_config_list(
+                    "custom_keymap", "CustomKeymap", backup["keymaps"]
+                )
 
-                if "dictionary" in selected_keys:
-                    dict_path = self._get_local_dict_path()
-                    os.makedirs(os.path.dirname(dict_path), exist_ok=True)
-                    with open(dict_path, "wb") as f:
-                        f.write(zipf.read("dictionary.txt"))
+            if "rules" in selected_keys and "rules" in backup:
+                self.dbus.set_sub_config_list("app_rules", "Rules", backup["rules"])
+
+            if "dictionary" in selected_keys and "dictionary" in backup:
+                dict_path = self._get_local_dict_path()
+                os.makedirs(os.path.dirname(dict_path), exist_ok=True)
+                with open(dict_path, "w", encoding="utf-8") as f:
+                    f.write(backup["dictionary"])
 
             QMessageBox.information(
                 self,
@@ -286,4 +310,6 @@ class BackupPage(QWidget):
             self.restore_data = None
 
         except Exception as e:
-            QMessageBox.critical(self, _("Error"), _("Failed to restore backup:\n") + str(e))
+            QMessageBox.critical(
+                self, _("Error"), _("Failed to restore backup:\n") + str(e)
+            )

--- a/settings-gui/ui/pages/dict_editor.py
+++ b/settings-gui/ui/pages/dict_editor.py
@@ -342,7 +342,7 @@ class DictEditorPage(BaseEditorPage):
         self._on_item_changed()
         self._update_add_button_icon()
 
-    def on_import(self):
+    def do_import(self):
         path, _filter = QFileDialog.getOpenFileName(
             self,
             _("Import Custom Dictionary"),
@@ -393,7 +393,7 @@ class DictEditorPage(BaseEditorPage):
             _(f"Imported {imported} words."),
         )
 
-    def on_export(self):
+    def do_export(self):
         if not self.words:
             QMessageBox.information(
                 self, _("Export"), _("The custom dictionary is empty, nothing to export.")

--- a/settings-gui/ui/pages/keymap_editor.py
+++ b/settings-gui/ui/pages/keymap_editor.py
@@ -329,10 +329,7 @@ class KeymapEditorPage(BaseEditorPage):
         self.btn_remove.setToolTip(_("Remove selected row"))
         self.btn_remove.clicked.connect(self.on_remove)
 
-        btn_import = QPushButton(QIcon.fromTheme("document-import"), _("Import"))
-        btn_export = QPushButton(QIcon.fromTheme("document-export"), _("Export"))
-        btn_import.clicked.connect(self.on_import)
-        btn_export.clicked.connect(self.on_export)
+        self.btn_remove.clicked.connect(self.on_remove)
 
         toolbar_layout.addWidget(self.btn_remove)
         toolbar_layout.addStretch()
@@ -486,7 +483,7 @@ class KeymapEditorPage(BaseEditorPage):
         if cell_combo:
             self.combo_action.setCurrentIndex(cell_combo.currentIndex())
 
-    def on_import(self):
+    def do_import(self):
         """Imports keymap from a TSV file."""
         path, _filter = QFileDialog.getOpenFileName(
             self,
@@ -555,7 +552,7 @@ class KeymapEditorPage(BaseEditorPage):
             _(f"Imported {imported} entries, skipped {skipped} invalid lines."),
         )
 
-    def on_export(self):
+    def do_export(self):
         """Exports the current table to a TSV file."""
         if self.table.rowCount() == 0:
             QMessageBox.information(

--- a/settings-gui/ui/pages/keymap_editor.py
+++ b/settings-gui/ui/pages/keymap_editor.py
@@ -329,7 +329,7 @@ class KeymapEditorPage(BaseEditorPage):
         self.btn_remove.setToolTip(_("Remove selected row"))
         self.btn_remove.clicked.connect(self.on_remove)
 
-        self.btn_remove.clicked.connect(self.on_remove)
+
 
         toolbar_layout.addWidget(self.btn_remove)
         toolbar_layout.addStretch()

--- a/settings-gui/ui/pages/macro_editor.py
+++ b/settings-gui/ui/pages/macro_editor.py
@@ -128,14 +128,9 @@ class MacroEditorPage(BaseEditorPage):
         self.btn_down = QPushButton(QIcon.fromTheme("go-down"), "")
         self.btn_down.setToolTip(_("Move Down"))
 
-        self.btn_import = QPushButton(QIcon.fromTheme("document-import"), _("Import"))
-        self.btn_export = QPushButton(QIcon.fromTheme("document-export"), _("Export"))
-
         self.btn_remove.clicked.connect(self.on_remove)
         self.btn_up.clicked.connect(self.on_move_up)
         self.btn_down.clicked.connect(self.on_move_down)
-        self.btn_import.clicked.connect(self.on_import)
-        self.btn_export.clicked.connect(self.on_export)
 
         toolbar_layout.addWidget(self.btn_remove)
         toolbar_layout.addWidget(self.btn_up)
@@ -372,7 +367,7 @@ class MacroEditorPage(BaseEditorPage):
             self.input_val.setText(val_item.text())
         self.update_button_states()
 
-    def on_import(self):
+    def do_import(self):
         path, _filter = QFileDialog.getOpenFileName(
             self,
             _("Import Macros"),
@@ -427,7 +422,7 @@ class MacroEditorPage(BaseEditorPage):
             _(f"Imported {imported} entries, skipped {skipped} invalid lines."),
         )
 
-    def on_export(self):
+    def do_export(self):
         if self.table.rowCount() == 0:
             QMessageBox.information(
                 self, _("Export"), _("The macro list is empty, nothing to export.")

--- a/settings-gui/ui/pages/mode_manager.py
+++ b/settings-gui/ui/pages/mode_manager.py
@@ -686,7 +686,7 @@ class ModeManagerPage(QWidget):
             or self.combo_global_mode.currentText() != "Uinput (Smooth)"
         )
 
-    def on_import(self):
+    def do_import(self):
         """Imports app rules from a TSV file."""
         path, _filter = QFileDialog.getOpenFileName(
             self,
@@ -754,7 +754,7 @@ class ModeManagerPage(QWidget):
             _(f"Imported {imported} rules, skipped {skipped} invalid lines."),
         )
 
-    def on_export(self):
+    def do_export(self):
         """Exports current app rules to a TSV file."""
         if not self.app_rules:
             QMessageBox.information(


### PR DESCRIPTION
This pull request introduces a new Backup and Restore page to the settings GUI, allowing users to export and import their Lotus configuration, macros, keymaps, rules, and dictionary as ZIP-based backups. Additionally, it standardizes import/export method names across several settings pages for consistency and removes unused import/export buttons from toolbars where not needed.

**Backup and Restore functionality:**

* Added a new `BackupPage` (`ui/pages/backup.py`) that enables users to selectively export and import settings, macros, keymaps, rules, and custom dictionary using a ZIP-based `.lotusbak` file. The page supports selective restore of components, shows available items in a backup, and provides user feedback on success or failure.
* Integrated the new Backup page into the main window's sidebar and navigation. [[1]](diffhunk://#diff-2718e5880d8bb8d029c56f7b8e929d92cfc7cc0217ea7e330b05f81aadb48efdR33) [[2]](diffhunk://#diff-2718e5880d8bb8d029c56f7b8e929d92cfc7cc0217ea7e330b05f81aadb48efdR206-R210)

**Import/Export method naming consistency:**

* Renamed all `on_import` and `on_export` methods to `do_import` and `do_export` in the following files for consistency:
  - `dict_editor.py` [[1]](diffhunk://#diff-44c535d2e3fd4d7d3a3f918fdf369622e4fb94917e06db52e729452e09b228fcL345-R345) [[2]](diffhunk://#diff-44c535d2e3fd4d7d3a3f918fdf369622e4fb94917e06db52e729452e09b228fcL396-R396)
  - `keymap_editor.py` [[1]](diffhunk://#diff-f81e39e7b03334cf46fcd5d77b5ae20c539fd13dc792f4adc7895b3371d6ceefL489-R486) [[2]](diffhunk://#diff-f81e39e7b03334cf46fcd5d77b5ae20c539fd13dc792f4adc7895b3371d6ceefL558-R555)
  - `macro_editor.py` [[1]](diffhunk://#diff-252e3aab05a333f93c8b60e6d27b67ca0c90e2ab3692e5a1c804c09f56cd5f65L375-R370) [[2]](diffhunk://#diff-252e3aab05a333f93c8b60e6d27b67ca0c90e2ab3692e5a1c804c09f56cd5f65L430-R425)
  - `mode_manager.py` [[1]](diffhunk://#diff-82ec696e573d7834f996cc2624216d2fd596da9bb13c9aee4e103c179a085e14L689-R689) [[2]](diffhunk://#diff-82ec696e573d7834f996cc2624216d2fd596da9bb13c9aee4e103c179a085e14L757-R757)

**Toolbar cleanup:**

* Removed unused import/export buttons from the toolbars in `keymap_editor.py` and `macro_editor.py` to streamline the UI, as these actions are now handled elsewhere or are not needed in the toolbar. [[1]](diffhunk://#diff-f81e39e7b03334cf46fcd5d77b5ae20c539fd13dc792f4adc7895b3371d6ceefL332-R332) [[2]](diffhunk://#diff-252e3aab05a333f93c8b60e6d27b67ca0c90e2ab3692e5a1c804c09f56cd5f65L131-L138)

These changes collectively improve the user experience by providing a unified backup/restore workflow and making the codebase more consistent and maintainable.