### PR TITLE
Add dynamic macro feature

### DIFF
--- a/bamboo/bamboo-c.go
+++ b/bamboo/bamboo-c.go
@@ -21,6 +21,8 @@ import (
 			bool modernStyle;
 			bool freeMarking;
 			bool w2u;
+			const char *timeFormat;
+			const char *dateFormat;
 		} FcitxBambooEngineOption;
 	*/
 	"C"
@@ -121,6 +123,8 @@ func EngineSetOption(engine uintptr, option *C.FcitxBambooEngineOption) {
 		flags &= ^bamboo.Ew2uEnabled
 	}
 	bambooEngine.preeditor.SetFlag(flags)
+	bambooEngine.timeFormat = C.GoString(option.timeFormat)
+	bambooEngine.dateFormat = C.GoString(option.dateFormat)
 }
 
 //export NewEngine
@@ -151,6 +155,8 @@ func NewEngine(name *C.cchar, dictHandle uintptr, tableHandle uintptr) uintptr {
 		commitText:              "",
 		shouldRestoreKeyStrokes: false,
 		outputCharset:           "Unicode",
+		timeFormat:              "%H:%M",
+		dateFormat:              "%d/%m/%Y",
 	}
 	return uintptr(cgo.NewHandle(engine))
 }
@@ -192,6 +198,8 @@ func NewCustomEngine(definition **C.char, dictHandle uintptr, tableHandle uintpt
 		commitText:              "",
 		shouldRestoreKeyStrokes: false,
 		outputCharset:           "Unicode",
+		timeFormat:              "%H:%M",
+		dateFormat:              "%d/%m/%Y",
 	}
 
 	return uintptr(cgo.NewHandle(engine))

--- a/bamboo/fcitxbambooengine.go
+++ b/bamboo/fcitxbambooengine.go
@@ -10,6 +10,7 @@ package main
 import (
 	"bamboo-core"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 )
@@ -29,6 +30,8 @@ type FcitxBambooEngine struct {
 	shouldRestoreKeyStrokes bool
 	outputCharset           string
 	w2u                     bool
+	timeFormat              string
+	dateFormat              string
 }
 
 
@@ -76,8 +79,56 @@ func determineMacroCase(str string) uint8 {
 	return VnCaseAllCapital
 }
 
+var strftimeReplacer = strings.NewReplacer(
+	"%H", "15",
+	"%I", "03",
+	"%M", "04",
+	"%S", "05",
+	"%p", "PM",
+	"%P", "pm",
+	"%d", "02",
+	"%m", "01",
+	"%Y", "2006",
+	"%y", "06",
+	"%b", "Jan",
+	"%B", "January",
+	"%a", "Mon",
+	"%A", "Monday",
+	// Some common variants
+	"%D", "01/02/06",
+	"%F", "2006-01-02",
+	"%T", "15:04:05",
+	"%R", "15:04",
+)
+
+func (e *FcitxBambooEngine) formatTime(format string) string {
+	now := time.Now()
+	if format == "" {
+		return ""
+	}
+	layout := strftimeReplacer.Replace(format)
+	if layout == "" {
+		return ""
+	}
+	// If layout was not changed (no placeholders found), default to standard format
+	if layout == format && strings.Contains(format, "%") {
+		// Fallback to something reasonable if it looks like they tried to use placeholders
+		return now.Format("15:04:05 02/01/2006")
+	}
+	return now.Format(layout)
+}
+
 func (e *FcitxBambooEngine) expandMacro(str string) string {
 	var macroText = e.macroTable.GetText(str)
+
+	// Replace dynamic placeholders
+	if e.timeFormat != "" {
+		macroText = strings.ReplaceAll(macroText, "$TIME", e.formatTime(e.timeFormat))
+	}
+	if e.dateFormat != "" {
+		macroText = strings.ReplaceAll(macroText, "$DATE", e.formatTime(e.dateFormat))
+	}
+
 	if e.autoCapitalizeMacro {
 		switch determineMacroCase(str) {
 		case VnCaseAllSmall:

--- a/settings-gui/ui/pages/macro_editor.py
+++ b/settings-gui/ui/pages/macro_editor.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
     QAbstractItemView,
     QFileDialog,
     QCheckBox,
+    QComboBox,
 )
 from PySide6.QtGui import QIcon, QColor
 from PySide6.QtCore import Qt
@@ -80,6 +81,70 @@ class MacroEditorPage(BaseEditorPage):
         content_layout = QVBoxLayout()
         editor_card.content_layout.addLayout(content_layout)
         main_layout.addWidget(editor_card)
+
+        # Dynamic Macro Settings (Moved below the macro table)
+        dynamic_card = CardWidget("")
+        dynamic_layout = QVBoxLayout()
+        
+        # Hint text
+        hint_label = QLabel(_("Macros can use dynamic placeholders: $TIME (current time) and $DATE (current date)."))
+        hint_label.setWordWrap(True)
+        hint_label.setStyleSheet("color: gray; font-size: 13px;")
+        dynamic_layout.addWidget(hint_label)
+        
+        # Format Inputs
+        fmt_container = QWidget()
+        fmt_vbox = QVBoxLayout(fmt_container)
+        fmt_vbox.setContentsMargins(0, 5, 0, 0)
+        
+        # Time Format
+        time_layout = QHBoxLayout()
+        self.input_time_format = QComboBox()
+        self.input_time_format.setEditable(False)
+        self.input_time_format.currentIndexChanged.connect(self._on_item_changed)
+        
+        time_presets = [
+            ("%H:%M", _("15:04 (24h)")),
+            ("%H:%M:%S", _("15:04:05 (24h)")),
+            ("%I:%M %p", _("03:04 PM")),
+            ("%I:%M:%S %p", _("03:04:05 PM")),
+            ("", _("None (Do not replace $TIME)")),
+        ]
+        for fmt, desc in time_presets:
+            self.input_time_format.addItem(fmt, fmt)
+            self.input_time_format.setItemData(self.input_time_format.count() - 1, desc, Qt.ToolTipRole)
+
+        time_layout.addWidget(QLabel(_("Time Format:")))
+        time_layout.addWidget(self.input_time_format, 1)
+        
+        # Date Format
+        date_layout = QHBoxLayout()
+        self.input_date_format = QComboBox()
+        self.input_date_format.setEditable(False)
+        self.input_date_format.currentIndexChanged.connect(self._on_item_changed)
+
+        date_presets = [
+            ("%d/%m/%Y", _("dd/MM/yyyy")),
+            ("%d/%m/%y", _("dd/MM/yy")),
+            ("%m/%d/%Y", _("MM/dd/yyyy")),
+            ("%Y-%m-%d", _("yyyy-MM-dd")),
+            ("%y-%m-%d", _("yy-MM-dd")),
+            ("", _("None (Do not replace $DATE)")),
+        ]
+        for fmt, desc in date_presets:
+            self.input_date_format.addItem(fmt, fmt)
+            self.input_date_format.setItemData(self.input_date_format.count() - 1, desc, Qt.ToolTipRole)
+
+        date_layout.addWidget(QLabel(_("Date Format:")))
+        date_layout.addWidget(self.input_date_format, 1)
+        
+        fmt_vbox.addLayout(time_layout)
+        fmt_vbox.addLayout(date_layout)
+        
+        dynamic_layout.addWidget(fmt_container)
+        
+        dynamic_card.content_layout.addLayout(dynamic_layout)
+        main_layout.addWidget(dynamic_card)
 
         # 1. Input Row (Top)
         input_layout = QHBoxLayout()
@@ -153,6 +218,22 @@ class MacroEditorPage(BaseEditorPage):
                 self.cb_capitalize.setChecked(
                     str(values.get("CapitalizeMacro", "True")).lower() == "true"
                 )
+                # Set time format (default %H:%M)
+                time_fmt = values.get("TimeFormat", "%H:%M")
+                index = self.input_time_format.findData(time_fmt)
+                if index >= 0:
+                    self.input_time_format.setCurrentIndex(index)
+                else:
+                    # Fallback to default if not in list (since it's not editable anymore)
+                    self.input_time_format.setCurrentIndex(self.input_time_format.findData("%H:%M"))
+
+                # Set date format
+                date_fmt = values.get("DateFormat", "%d/%m/%Y")
+                index = self.input_date_format.findData(date_fmt)
+                if index >= 0:
+                    self.input_date_format.setCurrentIndex(index)
+                else:
+                    self.input_date_format.setCurrentIndex(self.input_date_format.findData("%d/%m/%Y"))
 
             self.table.setRowCount(0)
             data = self.dbus.get_sub_config_list("lotus-macro", "Macro")
@@ -201,6 +282,8 @@ class MacroEditorPage(BaseEditorPage):
             "data": data,
             "EnableMacro": self.cb_enable.isChecked(),
             "CapitalizeMacro": self.cb_capitalize.isChecked(),
+            "TimeFormat": self.input_time_format.currentText(),
+            "DateFormat": self.input_date_format.currentText(),
         }
 
     def save_data(self):
@@ -212,6 +295,8 @@ class MacroEditorPage(BaseEditorPage):
             values["CapitalizeMacro"] = (
                 "True" if self.cb_capitalize.isChecked() else "False"
             )
+            values["TimeFormat"] = self.input_time_format.currentText()
+            values["DateFormat"] = self.input_date_format.currentText()
             self.dbus.set_config(values)
 
         data = []

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -128,6 +128,24 @@ namespace fcitx {
     };
 
     /**
+     * @brief Annotation for time format list.
+     */
+    struct TimeFormatAnnotation : public StringListAnnotation {
+        TimeFormatAnnotation() {
+            list_ = {"%H:%M:%S", "%H:%M", "%I:%M:%S %p", "%I:%M %p"};
+        }
+    };
+
+    /**
+     * @brief Annotation for date format list.
+     */
+    struct DateFormatAnnotation : public StringListAnnotation {
+        DateFormatAnnotation() {
+            list_ = {"%d/%m/%Y", "%m/%d/%Y", "%Y-%m-%d", "%d/%m/%y", "%y-%m-%d"};
+        }
+    };
+
+    /**
      * @brief Annotation for mode list with predefined options.
      */
     struct ModeListAnnotation : public StringListAnnotation {
@@ -206,13 +224,15 @@ namespace fcitx {
         Option<bool> w2u{this, "W2U", _("Type w to Produce ư"), true}; Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
         Option<bool>                                                                modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
         Option<bool>                                                                freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
-        Option<bool>    ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
-        Option<bool>    fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        Option<bool>    useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
-        Option<bool>    enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
-        Option<bool>    enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
-        SubConfigOption macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
-        SubConfigOption customKeymap{this, "CustomKeymap", _("Custom Keymap"), "fcitx://config/addon/lotus/custom_keymap"};
+        Option<bool>                                            ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
+        Option<bool>                                            fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
+        Option<bool>                                            useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
+        Option<bool>                                            enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
+        Option<bool>                                            enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
+        OptionWithAnnotation<std::string, TimeFormatAnnotation> timeFormat{this, "TimeFormat", _("Time Format ($TIME in macro)"), "%H:%M", {}, {}, TimeFormatAnnotation()};
+        OptionWithAnnotation<std::string, DateFormatAnnotation> dateFormat{this, "DateFormat", _("Date Format ($DATE in macro)"), "%d/%m/%Y", {}, {}, DateFormatAnnotation()};
+        SubConfigOption                                         macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
+        SubConfigOption                                         customKeymap{this, "CustomKeymap", _("Custom Keymap"), "fcitx://config/addon/lotus/custom_keymap"};
         SubConfigOption appRules{this, "AppRules", _("App Rules"), "fcitx://config/addon/lotus/app_rules"}; KeyListOption modeMenuKey{
             this, "ModeMenuKey", _("Mode Menu Hotkey"), {Key("grave")}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};);
 

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -70,6 +70,8 @@ namespace fcitx {
             .modernStyle         = *engine_->config().modernStyle,
             .freeMarking         = *engine_->config().freeMarking,
             .w2u                 = *engine_->config().w2u,
+            .timeFormat          = engine_->config().timeFormat->data(),
+            .dateFormat          = engine_->config().dateFormat->data(),
         };
 
         EngineSetOption(lotusEngine_.handle(), &option);


### PR DESCRIPTION
This pull request adds support for dynamic macros that can include customizable time and date placeholders in macro expansions. It introduces new options for users to set their preferred time and date formats, as well as an advanced formatting toggle. The settings UI is updated to allow users to configure these options, and the backend is updated to handle and apply the new formatting logic.

**Dynamic Macro Formatting Support:**

* Added new fields (`timeFormat`, `dateFormat`, `advancedMacroFormat`) to the `FcitxBambooEngine` struct and related C/C++ option structures to support customizable time and date formats in macros. [[1]](diffhunk://#diff-6f6a7640f6365247436cb2611400ae0bf85999c6344a85bff476eca5a12a7248R24-R26) [[2]](diffhunk://#diff-97d751b173f892825c46dd9a93f503ffe56a9037a8e9732c022a898e3bfe6afaR33-R35) [[3]](diffhunk://#diff-0747c15b20f347a2c0096feec91525cd3d73f87124df97670cd41fa00ddf26afR209-R211)
* Updated engine initialization and option-setting logic to handle the new fields, including sensible defaults for time and date formats. [[1]](diffhunk://#diff-6f6a7640f6365247436cb2611400ae0bf85999c6344a85bff476eca5a12a7248R127-R129) [[2]](diffhunk://#diff-6f6a7640f6365247436cb2611400ae0bf85999c6344a85bff476eca5a12a7248R160-R161) [[3]](diffhunk://#diff-6f6a7640f6365247436cb2611400ae0bf85999c6344a85bff476eca5a12a7248R203-R204) [[4]](diffhunk://#diff-1e09ae8b8fc92d8e5b3d72b17aaba69655af2890cb6b36817dea294143cb5f67R73-R75)

**Macro Expansion Logic:**

* Implemented the `formatTime` method in `FcitxBambooEngine` to process format strings (with strftime-like placeholders) and expanded macro logic to replace `$TIME` and `$DATE` placeholders with formatted values.

**Settings UI Enhancements:**

* Added a new "Dynamic Macros" section to the macro editor UI, allowing users to toggle advanced formatting and specify time/date formats with helpful descriptions.
* Updated UI logic to load, display, and save the new macro formatting options, including handling the advanced toggle and input fields. [[1]](diffhunk://#diff-252e3aab05a333f93c8b60e6d27b67ca0c90e2ab3692e5a1c804c09f56cd5f65R204-R209) [[2]](diffhunk://#diff-252e3aab05a333f93c8b60e6d27b67ca0c90e2ab3692e5a1c804c09f56cd5f65R258-R260) [[3]](diffhunk://#diff-252e3aab05a333f93c8b60e6d27b67ca0c90e2ab3692e5a1c804c09f56cd5f65R272-R276) [[4]](diffhunk://#diff-252e3aab05a333f93c8b60e6d27b67ca0c90e2ab3692e5a1c804c09f56cd5f65R514-R517)

**Dependencies:**

* Imported the Go `time` package to support time formatting in macro expansions.