### PR TITLE
refactor(nix): describe `user` option in nixos module

### DIFF
--- a/nix/modules/nixos/fcitx5-lotus/default.nix
+++ b/nix/modules/nixos/fcitx5-lotus/default.nix
@@ -14,6 +14,7 @@ in {
     user = mkOption {
       type = types.str;
       default = "";
+      description = "User name of the Server";
     };
   };
 


### PR DESCRIPTION
this commit adds [`description` argument](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.options.mkOption:~:text=option%20documentation), which lets [e.g. nixos](https://search.nixos.org/options?channel=unstable&query=documentation.nixos&show=documentation.nixos.includeAllModules) generate local doc of the module
