### PR TITLE
hotfix: in surrounding text mode, expand forwarding key condition when deletedPart == oldWord

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -607,13 +607,7 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, commonPrefix, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                bool isBrokenComposition = (deletedPart == oldPreBuffer_ && addedPart == keyUtf8);
-                if (isBrokenComposition) {
-                    ic_->commitString(addedPart);
-                    LOTUS_INFO("Broken composition, commit only: " + addedPart);
-                } else {
-                    performReplacement(deletedPart, addedPart);
-                }
+                performReplacement(deletedPart, addedPart);
                 keyEvent.filterAndAccept();
             } else {
                 bool wasAutoCapitalized = (currentSym != keyEvent.rawKey().sym());

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -607,8 +607,15 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, commonPrefix, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                performReplacement(deletedPart, addedPart);
-                keyEvent.filterAndAccept();
+                bool isBrokenComposition = (deletedPart == oldPreBuffer_ && addedPart == keyUtf8);
+                if (isBrokenComposition) {
+                    ic_->commitString(addedPart);
+                    LOTUS_INFO("Broken composition, commit only: " + addedPart);
+                    keyEvent.filterAndAccept();
+                } else {
+                    performReplacement(deletedPart, addedPart);
+                    keyEvent.filterAndAccept();
+                }
             } else {
                 bool wasAutoCapitalized = (currentSym != keyEvent.rawKey().sym());
                 if (!addedPart.empty() && (keyUtf8 != addedPart || wasAutoCapitalized)) {
@@ -792,7 +799,7 @@ namespace fcitx {
             std::string deletedPart;
             std::string addedPart;
             compareAndSplitStrings(oldWord, newWord, commonPrefix, deletedPart, addedPart);
-            if (deletedPart.empty() && addedPart == keyEvent.key().toString()) {
+            if ((deletedPart.empty() || deletedPart == oldWord) && addedPart == keyEvent.key().toString()) {
                 ResetEngine(lotusEngine_.handle());
                 keyEvent.forward();
                 return;

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -793,7 +793,6 @@ namespace fcitx {
             std::string addedPart;
             compareAndSplitStrings(oldWord, newWord, commonPrefix, deletedPart, addedPart);
             if ((deletedPart.empty() || deletedPart == oldWord) && addedPart == keyEvent.key().toString()) {
-                LOTUS_INFO("Broken composition in Surrounding Text, forwarding key: " + addedPart);
                 ResetEngine(lotusEngine_.handle());
                 keyEvent.forward();
                 return;

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -611,11 +611,10 @@ namespace fcitx {
                 if (isBrokenComposition) {
                     ic_->commitString(addedPart);
                     LOTUS_INFO("Broken composition, commit only: " + addedPart);
-                    keyEvent.filterAndAccept();
                 } else {
                     performReplacement(deletedPart, addedPart);
-                    keyEvent.filterAndAccept();
                 }
+                keyEvent.filterAndAccept();
             } else {
                 bool wasAutoCapitalized = (currentSym != keyEvent.rawKey().sym());
                 if (!addedPart.empty() && (keyUtf8 != addedPart || wasAutoCapitalized)) {
@@ -800,6 +799,7 @@ namespace fcitx {
             std::string addedPart;
             compareAndSplitStrings(oldWord, newWord, commonPrefix, deletedPart, addedPart);
             if ((deletedPart.empty() || deletedPart == oldWord) && addedPart == keyEvent.key().toString()) {
+                LOTUS_INFO("Broken composition in Surrounding Text, forwarding key: " + addedPart);
                 ResetEngine(lotusEngine_.handle());
                 keyEvent.forward();
                 return;


### PR DESCRIPTION
#217