### PR TITLE
hotfix(settings-gui): Ensure Fcitx5 Engine Compatibility

### DIFF
--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -68,6 +68,9 @@ HOTKEY_UI_UNSHIFT_MAP = {
     "less": "comma", "greater": "period", "question": "slash"
 }
 
+for char in "abcdefghijklmnopqrstuvwxyz":
+    HOTKEY_UI_UNSHIFT_MAP[char.upper()] = char
+
 
 def pretty_format_hotkey_parts(hotkey_str):
     """Converts internal keysym names to user-friendly characters for display as a list.

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -80,19 +80,22 @@ HOTKEY_SYM_MAP = {
     "ISO_Left_Tab": "Tab",
 }
 
-# Mapping to "unshift" symbols back to their base keys when Shift is used (standard US-like layout)
-HOTKEY_UNSHIFT_MAP = {
+
+# Mapping for UI DISPLAY ONLY: Converts shifted keysyms back to base keys + explicit Shift label.
+# This keeps the stored string engine-compliant (e.g. 'asciitilde') but UI-friendly (e.g. 'Shift' + '`').
+HOTKEY_UI_UNSHIFT_MAP = {
+    "asciitilde": "grave",
     "exclam": "1", "at": "2", "numbersign": "3", "dollar": "4", "percent": "5",
     "asciicircum": "6", "ampersand": "7", "asterisk": "8", "parenleft": "9", "parenright": "0",
     "underscore": "minus", "plus": "equal", "braceleft": "bracketleft", "braceright": "bracketright",
     "bar": "backslash", "colon": "semicolon", "quotedbl": "apostrophe",
-    "less": "comma", "greater": "period", "question": "slash", "asciitilde": "grave",
-    "ISO_Left_Tab": "Tab"
+    "less": "comma", "greater": "period", "question": "slash"
 }
 
 
 def pretty_format_hotkey_parts(hotkey_str):
-    """Converts internal keysym names to user-friendly characters for display as a list."""
+    """Converts internal keysym names to user-friendly characters for display as a list.
+    Automatically de-normalizes shifted keysyms for better UI (e.g., 'asciitilde' -> ['Shift', '`'])."""
     if not hotkey_str:
         return []
 
@@ -104,11 +107,44 @@ def pretty_format_hotkey_parts(hotkey_str):
     else:
         parts = hotkey_str.split("+")
 
-    pretty_parts = []
+    raw_mods = []
+    base_key_part = None
+    
+    # Analyze parts to identify modifiers and the base key
     for part in parts:
-        if not part:
-            continue  # Handles trailing or consecutive '+' from split()
-        pretty_parts.append(HOTKEY_SYM_MAP.get(part, part.capitalize()))
+        if not part: continue
+        if part in ("Control", "Alt", "Super", "Shift"):
+            if part not in raw_mods:
+                raw_mods.append(part)
+        else:
+            base_key_part = part
+
+    pretty_parts = []
+    explicit_shift_needed = "Shift" in raw_mods
+
+    # Process base key for UI display
+    if base_key_part:
+        # Check for symbols that imply Shift (Display only)
+        if base_key_part in HOTKEY_UI_UNSHIFT_MAP:
+            explicit_shift_needed = True
+            display_base = HOTKEY_UI_UNSHIFT_MAP[base_key_part]
+            base_key_label = HOTKEY_SYM_MAP.get(display_base, display_base.capitalize())
+        elif len(base_key_part) == 1 and base_key_part.isupper():
+            explicit_shift_needed = True
+            base_key_label = base_key_part # Keep uppercase A-Z
+        else:
+            base_key_label = HOTKEY_SYM_MAP.get(base_key_part, base_key_part.capitalize())
+    else:
+        base_key_label = ""
+
+    # Build the final ordered list of labels
+    if "Control" in raw_mods: pretty_parts.append(_("Ctrl"))
+    if "Alt" in raw_mods: pretty_parts.append(_("Alt"))
+    if "Super" in raw_mods: pretty_parts.append(_("Super"))
+    if explicit_shift_needed: pretty_parts.append(_("Shift"))
+    
+    if base_key_label:
+        pretty_parts.append(base_key_label)
 
     return pretty_parts
 
@@ -211,18 +247,23 @@ class HotkeyCaptureWidget(QPushButton):
         base_key = ""
 
         if libxkb and keysym > 0:
-            # Always try to use the lower-case/base version of the keysym
-            lower_sym = libxkb.xkb_keysym_to_lower(keysym)
-            
+            # Use raw keysym name to ensure compatibility with Fcitx5 engine (Alt+O vs Alt+o)
             buf = ctypes.create_string_buffer(64)
-            if libxkb.xkb_keysym_get_name(lower_sym, buf, 64) > 0:
+            if libxkb.xkb_keysym_get_name(keysym, buf, 64) > 0:
                 base_key = buf.value.decode("utf-8")
-
-        if event.modifiers() & Qt.ShiftModifier and base_key in HOTKEY_UNSHIFT_MAP:
-            base_key = HOTKEY_UNSHIFT_MAP[base_key]
 
         if not base_key:
             base_key = event.text() if event.text() and event.text().isprintable() else QKeySequence(key_code).toString()
+
+        # Detect if the keysym already implies a Shift state to avoid redundancy (e.g. 'Shift+~')
+        # We check for uppercase letters or symbol names that standard US layout produces with Shift
+        shifted_symbols = {
+            "asciitilde", "exclam", "at", "numbersign", "dollar", "percent",
+            "asciicircum", "ampersand", "asterisk", "parenleft", "parenright",
+            "underscore", "plus", "braceleft", "braceright", "bar", "colon",
+            "quotedbl", "less", "greater", "question"
+        }
+        is_implicitly_shifted = (len(base_key) == 1 and base_key.isupper()) or base_key in shifted_symbols
 
         mods = []
         if event.modifiers() & Qt.ControlModifier:
@@ -232,7 +273,8 @@ class HotkeyCaptureWidget(QPushButton):
         if event.modifiers() & Qt.MetaModifier:
             mods.append("Super")
 
-        if event.modifiers() & Qt.ShiftModifier:
+        # Only append Shift if it's not already implied by the keysym (e.g. 'Shift+1' is needed, but 'Shift+!' is redundant)
+        if event.modifiers() & Qt.ShiftModifier and not is_implicitly_shifted:
             mods.append("Shift")
 
         mods.append(base_key)

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -39,45 +39,20 @@ if libxkb_path:
 
 # Common XKB keysym name to character mapping for display
 HOTKEY_SYM_MAP = {
-    "grave": "`",
-    "minus": "-",
-    "equal": "=",
-    "bracketleft": "[",
-    "bracketright": "]",
-    "backslash": "\\",
-    "semicolon": ";",
-    "apostrophe": "'",
-    "comma": ",",
-    "period": ".",
-    "slash": "/",
-    "asciitilde": "~",
-    "underscore": "_",
-    "plus": "+",
-    "braceleft": "{",
-    "braceright": "}",
-    "bar": "|",
-    "colon": ":",
-    "quotedbl": '"',
-    "less": "<",
-    "greater": ">",
-    "question": "?",
-    "exclam": "!",
-    "at": "@",
-    "numbersign": "#",
-    "dollar": "$",
-    "percent": "%",
-    "asciicircum": "^",
-    "ampersand": "&",
-    "asterisk": "*",
-    "parenleft": "(",
-    "parenright": ")",
-    "Control": "Ctrl",
-    "Escape": "Esc",
-    "Return": "Enter",
-    "BackSpace": "Backspace",
-    "Delete": "Del",
-    "Insert": "Ins",
-    "ISO_Left_Tab": "Tab",
+    "grave": "`", "minus": "-", "equal": "=", "bracketleft": "[", "bracketright": "]",
+    "backslash": "\\", "semicolon": ";", "apostrophe": "'", "comma": ",", "period": ".",
+    "slash": "/", "asciitilde": "~", "underscore": "_", "plus": "+",
+    "braceleft": "{", "braceright": "}", "bar": "|", "colon": ":", "quotedbl": '"',
+    "less": "<", "greater": ">", "question": "?", "exclam": "!", "at": "@",
+    "numbersign": "#", "dollar": "$", "percent": "%", "asciicircum": "^",
+    "ampersand": "&", "asterisk": "*", "parenleft": "(", "parenright": ")",
+    "Control": "Ctrl", "Escape": "Esc", "Return": "Enter", "BackSpace": "Backspace",
+    "Delete": "Del", "Insert": "Ins", "ISO_Left_Tab": "Tab",
+    "Shift_L": "L-Shift", "Shift_R": "R-Shift",
+    "Control_L": "L-Ctrl", "Control_R": "R-Ctrl",
+    "Alt_L": "L-Alt", "Alt_R": "R-Alt",
+    "Super_L": "L-Super", "Super_R": "R-Super",
+    "Meta_L": "L-Super", "Meta_R": "R-Super",
 }
 
 
@@ -95,7 +70,7 @@ HOTKEY_UI_UNSHIFT_MAP = {
 
 def pretty_format_hotkey_parts(hotkey_str):
     """Converts internal keysym names to user-friendly characters for display as a list.
-    Automatically de-normalizes shifted keysyms for better UI (e.g., 'asciitilde' -> ['Shift', '`'])."""
+    Automatically de-normalizes shifted keysyms and de-duplicates redundant modifiers."""
     if not hotkey_str:
         return []
 
@@ -118,6 +93,18 @@ def pretty_format_hotkey_parts(hotkey_str):
                 raw_mods.append(part)
         else:
             base_key_part = part
+
+    # De-duplicate: If base key IS a specific modifier (e.g. Shift_L),
+    # suppress the corresponding generic modifier label.
+    if base_key_part:
+        if base_key_part.startswith("Shift_"):
+            if "Shift" in raw_mods: raw_mods.remove("Shift")
+        elif base_key_part.startswith("Control_") or base_key_part == "Control":
+            if "Control" in raw_mods: raw_mods.remove("Control")
+        elif base_key_part.startswith("Alt_") or base_key_part == "Alt":
+            if "Alt" in raw_mods: raw_mods.remove("Alt")
+        elif base_key_part.startswith("Super_") or base_key_part.startswith("Meta_"):
+            if "Super" in raw_mods: raw_mods.remove("Super")
 
     pretty_parts = []
     explicit_shift_needed = "Shift" in raw_mods
@@ -222,7 +209,6 @@ class HotkeyCaptureWidget(QPushButton):
         if not self.isChecked():
             super().keyPressEvent(event)
             return
-        # Recording events are handled by eventFilter to intercept navigation keys
 
     def _handle_key_event(self, event):
         """Internal helper to process captured keys."""
@@ -243,11 +229,12 @@ class HotkeyCaptureWidget(QPushButton):
         ):
             return
 
+        # It's a base key! Capture it and finalize immediately
         keysym = event.nativeVirtualKey()
         base_key = ""
 
         if libxkb and keysym > 0:
-            # Use raw keysym name to ensure compatibility with Fcitx5 engine (Alt+O vs Alt+o)
+            # Use raw keysym name to ensure compatibility with Fcitx5 engine
             buf = ctypes.create_string_buffer(64)
             if libxkb.xkb_keysym_get_name(keysym, buf, 64) > 0:
                 base_key = buf.value.decode("utf-8")
@@ -255,32 +242,23 @@ class HotkeyCaptureWidget(QPushButton):
         if not base_key:
             base_key = event.text() if event.text() and event.text().isprintable() else QKeySequence(key_code).toString()
 
-        # Detect if the keysym is a specific "shifted symbol" name (e.g. 'asciitilde' for '~').
-        # Fcitx5 usually expects these WITHOUT a redundant "Shift" modifier in the string.
-        # However, for letters (A-Z), we keep "Shift" explicit for better compatibility and UI.
+        # Build modifier list from current event state
+        mods = []
+        if event.modifiers() & Qt.ControlModifier: mods.append("Control")
+        if event.modifiers() & Qt.AltModifier: mods.append("Alt")
+        if event.modifiers() & Qt.MetaModifier: mods.append("Super")
+
+        # Selective Shift suppression for symbols
         shifted_symbols = {
             "asciitilde", "exclam", "at", "numbersign", "dollar", "percent",
             "asciicircum", "ampersand", "asterisk", "parenleft", "parenright",
             "underscore", "plus", "braceleft", "braceright", "bar", "colon",
             "quotedbl", "less", "greater", "question"
         }
-        is_symbol_shifted = base_key in shifted_symbols
-
-        mods = []
-        if event.modifiers() & Qt.ControlModifier:
-            mods.append("Control")
-        if event.modifiers() & Qt.AltModifier:
-            mods.append("Alt")
-        if event.modifiers() & Qt.MetaModifier:
-            mods.append("Super")
-
-        # Only append Shift if it's not already implied by a technical symbol name.
-        # We ALWAYS append it for letters if Shift is held to ensure Fcitx5 sees 'Shift+O'.
-        if event.modifiers() & Qt.ShiftModifier and not is_symbol_shifted:
+        if (event.modifiers() & Qt.ShiftModifier) and (base_key not in shifted_symbols):
             mods.append("Shift")
 
         mods.append(base_key)
         self.current_key = "+".join(mods)
-
         self.setChecked(False)
         self.textChanged.emit(self.current_key)

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -255,16 +255,6 @@ class HotkeyCaptureWidget(QPushButton):
         if not base_key:
             base_key = event.text() if event.text() and event.text().isprintable() else QKeySequence(key_code).toString()
 
-        # Detect if the keysym already implies a Shift state to avoid redundancy (e.g. 'Shift+~')
-        # We check for uppercase letters or symbol names that standard US layout produces with Shift
-        shifted_symbols = {
-            "asciitilde", "exclam", "at", "numbersign", "dollar", "percent",
-            "asciicircum", "ampersand", "asterisk", "parenleft", "parenright",
-            "underscore", "plus", "braceleft", "braceright", "bar", "colon",
-            "quotedbl", "less", "greater", "question"
-        }
-        is_implicitly_shifted = (len(base_key) == 1 and base_key.isupper()) or base_key in shifted_symbols
-
         mods = []
         if event.modifiers() & Qt.ControlModifier:
             mods.append("Control")
@@ -273,8 +263,7 @@ class HotkeyCaptureWidget(QPushButton):
         if event.modifiers() & Qt.MetaModifier:
             mods.append("Super")
 
-        # Only append Shift if it's not already implied by the keysym (e.g. 'Shift+1' is needed, but 'Shift+!' is redundant)
-        if event.modifiers() & Qt.ShiftModifier and not is_implicitly_shifted:
+        if event.modifiers() & Qt.ShiftModifier:
             mods.append("Shift")
 
         mods.append(base_key)

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -146,7 +146,8 @@ class KeyCap(QLabel):
 
 
 class HotkeyCaptureWidget(QPushButton):
-    """A button that captures keystrokes to set an Fcitx5-compatible hotkey."""
+    """A button that captures keystrokes to set an Fcitx5-compatible hotkey.
+    Provides live visual feedback for held modifiers during recording."""
 
     textChanged = Signal(str)
 
@@ -155,6 +156,9 @@ class HotkeyCaptureWidget(QPushButton):
         self.current_key = current_key
         self.setCheckable(True)
         self.setObjectName("HotkeyButton")
+        
+        # Local state to track held modifiers during recording
+        self.record_mods = set()
         
         # Use a layout for visual keycaps
         self.main_layout = QHBoxLayout(self)
@@ -165,7 +169,7 @@ class HotkeyCaptureWidget(QPushButton):
         self.toggled.connect(self._on_toggled)
         self._update_display()
 
-        # Install event filter to catch ShortcutOverride (used for mnemonics like Alt+O)
+        # Install event filter to catch KeyPress, KeyRelease and ShortcutOverride
         self.installEventFilter(self)
 
     def eventFilter(self, obj, event):
@@ -177,9 +181,14 @@ class HotkeyCaptureWidget(QPushButton):
             if event.type() == QEvent.KeyPress:
                 self._handle_key_event(event)
                 return True
+            if event.type() == QEvent.KeyRelease:
+                self._handle_release_event(event)
+                return True
         return super().eventFilter(obj, event)
 
     def _on_toggled(self, checked):
+        if checked:
+            self.record_mods.clear()
         self._update_display()
 
     def _clear_layout(self):
@@ -192,9 +201,20 @@ class HotkeyCaptureWidget(QPushButton):
         self._clear_layout()
         
         if self.isChecked():
-            lbl = QLabel(_("[ Recording... ]"))
-            lbl.setStyleSheet("color: palette(highlight); font-weight: bold;")
-            self.main_layout.addWidget(lbl)
+            if not self.record_mods:
+                lbl = QLabel(_("[ Recording... ]"))
+                lbl.setStyleSheet("color: palette(highlight); font-weight: bold;")
+                self.main_layout.addWidget(lbl)
+            else:
+                # Show current active modifiers
+                mod_order = ["Control", "Alt", "Super", "Shift"]
+                for mod in mod_order:
+                    if mod in self.record_mods:
+                        self.main_layout.addWidget(KeyCap(HOTKEY_SYM_MAP.get(mod, mod)))
+                # Add a pulsing placeholder for the next key
+                lbl = QLabel("...")
+                lbl.setStyleSheet("color: palette(highlight);")
+                self.main_layout.addWidget(lbl)
         elif not self.current_key:
             lbl = QLabel(_("None"))
             lbl.setStyleSheet("color: palette(mid);")
@@ -220,14 +240,19 @@ class HotkeyCaptureWidget(QPushButton):
             self.setChecked(False)
             return
 
-        # Ignore standalone modifier presses
-        if key_code in (
-            Qt.Key_Control,
-            Qt.Key_Shift,
-            Qt.Key_Alt,
-            Qt.Key_Meta,
-            Qt.Key_unknown,
-        ):
+        # Track modifiers in real-time
+        mod_map = {
+            Qt.Key_Control: "Control",
+            Qt.Key_Shift: "Shift",
+            Qt.Key_Alt: "Alt",
+            Qt.Key_Meta: "Super"
+        }
+        if key_code in mod_map:
+            self.record_mods.add(mod_map[key_code])
+            self._update_display()
+            return
+
+        if key_code == Qt.Key_unknown:
             return
 
         # It's a base key! Capture it and finalize immediately
@@ -249,12 +274,29 @@ class HotkeyCaptureWidget(QPushButton):
         if event.modifiers() & Qt.AltModifier: mods.append("Alt")
         if event.modifiers() & Qt.MetaModifier: mods.append("Super")
 
-        # Only append Shift if it's not already implied by a technical symbol name (from the UI map).
-        # We ALWAYS append it for letters (even uppercase) to ensure Fcitx5 sees 'Shift+O' explicitly.
-        if event.modifiers() & Qt.ShiftModifier and base_key not in HOTKEY_UI_UNSHIFT_MAP:
+        # Selective Shift suppression for symbols
+        if (event.modifiers() & Qt.ShiftModifier) and (base_key not in HOTKEY_UI_UNSHIFT_MAP):
             mods.append("Shift")
 
         mods.append(base_key)
         self.current_key = "+".join(mods)
         self.setChecked(False)
         self.textChanged.emit(self.current_key)
+
+    def _handle_release_event(self, event):
+        """Processes key release to update live feedback."""
+        if not self.isChecked():
+            return
+            
+        key_code = event.key()
+        mod_map = {
+            Qt.Key_Control: "Control",
+            Qt.Key_Shift: "Shift",
+            Qt.Key_Alt: "Alt",
+            Qt.Key_Meta: "Super"
+        }
+        if key_code in mod_map:
+            val = mod_map[key_code]
+            if val in self.record_mods:
+                self.record_mods.remove(val)
+                self._update_display()

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -64,7 +64,8 @@ HOTKEY_UI_UNSHIFT_MAP = {
     "asciicircum": "6", "ampersand": "7", "asterisk": "8", "parenleft": "9", "parenright": "0",
     "underscore": "minus", "plus": "equal", "braceleft": "bracketleft", "braceright": "bracketright",
     "bar": "backslash", "colon": "semicolon", "quotedbl": "apostrophe",
-    "less": "comma", "greater": "period", "question": "slash"
+    "less": "comma", "greater": "period", "question": "slash",
+    "ISO_Left_Tab": "Tab"
 }
 
 
@@ -248,14 +249,9 @@ class HotkeyCaptureWidget(QPushButton):
         if event.modifiers() & Qt.AltModifier: mods.append("Alt")
         if event.modifiers() & Qt.MetaModifier: mods.append("Super")
 
-        # Selective Shift suppression for symbols
-        shifted_symbols = {
-            "asciitilde", "exclam", "at", "numbersign", "dollar", "percent",
-            "asciicircum", "ampersand", "asterisk", "parenleft", "parenright",
-            "underscore", "plus", "braceleft", "braceright", "bar", "colon",
-            "quotedbl", "less", "greater", "question"
-        }
-        if (event.modifiers() & Qt.ShiftModifier) and (base_key not in shifted_symbols):
+        # Only append Shift if it's not already implied by a technical symbol name (from the UI map).
+        # We ALWAYS append it for letters (even uppercase) to ensure Fcitx5 sees 'Shift+O' explicitly.
+        if event.modifiers() & Qt.ShiftModifier and base_key not in HOTKEY_UI_UNSHIFT_MAP:
             mods.append("Shift")
 
         mods.append(base_key)

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -255,6 +255,17 @@ class HotkeyCaptureWidget(QPushButton):
         if not base_key:
             base_key = event.text() if event.text() and event.text().isprintable() else QKeySequence(key_code).toString()
 
+        # Detect if the keysym is a specific "shifted symbol" name (e.g. 'asciitilde' for '~').
+        # Fcitx5 usually expects these WITHOUT a redundant "Shift" modifier in the string.
+        # However, for letters (A-Z), we keep "Shift" explicit for better compatibility and UI.
+        shifted_symbols = {
+            "asciitilde", "exclam", "at", "numbersign", "dollar", "percent",
+            "asciicircum", "ampersand", "asterisk", "parenleft", "parenright",
+            "underscore", "plus", "braceleft", "braceright", "bar", "colon",
+            "quotedbl", "less", "greater", "question"
+        }
+        is_symbol_shifted = base_key in shifted_symbols
+
         mods = []
         if event.modifiers() & Qt.ControlModifier:
             mods.append("Control")
@@ -263,7 +274,9 @@ class HotkeyCaptureWidget(QPushButton):
         if event.modifiers() & Qt.MetaModifier:
             mods.append("Super")
 
-        if event.modifiers() & Qt.ShiftModifier:
+        # Only append Shift if it's not already implied by a technical symbol name.
+        # We ALWAYS append it for letters if Shift is held to ensure Fcitx5 sees 'Shift+O'.
+        if event.modifiers() & Qt.ShiftModifier and not is_symbol_shifted:
             mods.append("Shift")
 
         mods.append(base_key)

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -58,14 +58,14 @@ HOTKEY_SYM_MAP = {
 
 # Mapping for UI DISPLAY ONLY: Converts shifted keysyms back to base keys + explicit Shift label.
 # This keeps the stored string engine-compliant (e.g. 'asciitilde') but UI-friendly (e.g. 'Shift' + '`').
+# NOTE: We exclude ISO_Left_Tab here because Fcitx5 configuration prefers explicit 'Shift+Tab' strings.
 HOTKEY_UI_UNSHIFT_MAP = {
     "asciitilde": "grave",
     "exclam": "1", "at": "2", "numbersign": "3", "dollar": "4", "percent": "5",
     "asciicircum": "6", "ampersand": "7", "asterisk": "8", "parenleft": "9", "parenright": "0",
     "underscore": "minus", "plus": "equal", "braceleft": "bracketleft", "braceright": "bracketright",
     "bar": "backslash", "colon": "semicolon", "quotedbl": "apostrophe",
-    "less": "comma", "greater": "period", "question": "slash",
-    "ISO_Left_Tab": "Tab"
+    "less": "comma", "greater": "period", "question": "slash"
 }
 
 
@@ -264,6 +264,9 @@ class HotkeyCaptureWidget(QPushButton):
             buf = ctypes.create_string_buffer(64)
             if libxkb.xkb_keysym_get_name(keysym, buf, 64) > 0:
                 base_key = buf.value.decode("utf-8")
+                # Normalize BackTab keysym to Tab to ensure Fcitx5 sees 'Shift+Tab' instead of plain 'ISO_Left_Tab'
+                if base_key == "ISO_Left_Tab":
+                    base_key = "Tab"
 
         if not base_key:
             base_key = event.text() if event.text() and event.text().isprintable() else QKeySequence(key_code).toString()


### PR DESCRIPTION
**What**
This update resolves a mismatch between the Hotkey UI capture logic and the Fcitx5 engine's trigger expectations by implementing a decoupled architecture for hotkey representation.

**Why**
Previously, the UI attempted to simplify hotkeys (e.g., storing Shift+grave instead of asciitilde, or Alt+o instead of Alt+O). While visually appealing, these technical shortcuts caused the Fcitx5 engine to fail to register or trigger the hotkeys. This fix ensures that what is stored in the configuration is exactly what the engine requires, while the UI remains user-friendly.