### PR TITLE
feat: unify icon selection and themes

### DIFF
--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -49,7 +49,7 @@ SETTINGS_MAP = {
         ],
     },
     SettingsCategory.APPEARANCE: {
-        "THEME & ICONS": ["UseLotusIcons", "UseBlackDefaultIcons"],
+        "THEME & ICONS": ["IconTheme"],
     },
     SettingsCategory.TYPING: {
         "SPELLING & CORRECTIONS": ["SpellCheck", "AutoNonVnRestore", "DdFreeStyle"],

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -104,6 +104,7 @@ namespace fcitx {
          */
         void dumpDescription(RawConfig& config) const {
             EnumAnnotation::dumpDescription(config);
+            config.setValueByPath("IsEnum", "True");
             for (size_t i = 0; i < list_.size(); ++i) {
                 config.setValueByPath("Enum/" + std::to_string(i), list_[i]);
             }
@@ -154,6 +155,15 @@ namespace fcitx {
          */
         ModeListAnnotation() {
             list_ = {_("Uinput (Smooth)"), _("Uinput (Slow)"), _("Minecraft"), _("Surrounding Text"), _("Preedit"), _("Emoji Picker"), _("OFF")};
+        }
+    };
+
+    /**
+     * @brief Annotation for icon theme list.
+     */
+    struct IconThemeAnnotation : public StringListAnnotation {
+        IconThemeAnnotation() {
+            list_ = {_("Automatically"), _("Light"), _("Dark"), _("Lotus")};
         }
     };
 
@@ -224,12 +234,11 @@ namespace fcitx {
         Option<bool> w2u{this, "W2U", _("Type w to Produce ư"), true}; Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
         Option<bool>                                                                modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
         Option<bool>                                                                freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
-        Option<bool> ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
-        Option<bool> fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        Option<bool> useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
-        Option<bool> useBlackDefaultIcons{this, "UseBlackDefaultIcons", _("Use Black Default Icons"), false};
-        Option<bool> enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
-        Option<bool> enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
+        Option<bool>                                           ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
+        Option<bool>                                           fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
+        OptionWithAnnotation<std::string, IconThemeAnnotation> iconTheme{this, "IconTheme", _("Icon Selection"), "Automatically", {}, {}, IconThemeAnnotation()};
+        Option<bool>                                           enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
+        Option<bool>                                           enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
         Option<bool> showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true}; Option<bool> showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};
         Option<bool>                                                                                       showModeMinecraft{this, "ShowModeMinecraft", _("Show Minecraft"), true};
         Option<bool> showModeSurroundingText{this, "ShowModeSurroundingText", _("Show Surrounding Text"), true};

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -227,6 +227,10 @@ namespace fcitx {
         Option<std::string, InputMethodConstrain, DefaultMarshaller<std::string>, InputMethodAnnotation> inputMethod{
             this, "InputMethod", _("Input Method"), "Telex", InputMethodConstrain(&inputMethod), {}, InputMethodAnnotation()};
         OptionWithAnnotation<std::string, StringListAnnotation> outputCharset{this, "OutputCharset", _("Output Charset"), "Unicode", {}, {}, StringListAnnotation()};
+        KeyListOption                                           modeMenuKey{
+            this, "ModeMenuKey", _("Mode Menu Hotkey"), {Key("grave")}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};
+        SubConfigOption appRules{this, "AppRules", _("App Rules"), "fcitx://config/addon/lotus/app_rules"};
+
         Option<bool> spellCheck{this, "SpellCheck", _("Enable Spell Check"), true}; Option<bool> enableMacro{this, "EnableMacro", _("Enable Macro"), true};
         Option<bool> capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true}; Option<bool> autoCapitalizeAfterPunctuation{
             this, "AutoCapitalizeAfterPunctuation", _("Auto capitalize after sentence-ending punctuation (. ! ? Enter) (experimental)"), false};
@@ -234,22 +238,24 @@ namespace fcitx {
         Option<bool> w2u{this, "W2U", _("Type w to Produce ư"), true}; Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
         Option<bool>                                                                modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
         Option<bool>                                                                freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
-        Option<bool>                                           ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
-        Option<bool>                                           fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        OptionWithAnnotation<std::string, IconThemeAnnotation> iconTheme{this, "IconTheme", _("Icon Selection"), "Dark", {}, {}, IconThemeAnnotation()};
-        Option<bool>                                           enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
-        Option<bool>                                           enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
+        Option<bool> ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
+        Option<bool> fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
+
+        Option<bool> enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
+        Option<bool> enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
+
         Option<bool> showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true}; Option<bool> showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};
         Option<bool>                                                                                       showModeMinecraft{this, "ShowModeMinecraft", _("Show Minecraft"), true};
         Option<bool> showModeSurroundingText{this, "ShowModeSurroundingText", _("Show Surrounding Text"), true};
         Option<bool> showModePreedit{this, "ShowModePreedit", _("Show Preedit"), true}; Option<bool> showModeEmoji{this, "ShowModeEmoji", _("Show Emoji Picker"), true};
         Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true}; Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
+
         OptionWithAnnotation<std::string, TimeFormatAnnotation> timeFormat{this, "TimeFormat", _("Time Format ($TIME in macro)"), "%H:%M", {}, {}, TimeFormatAnnotation()};
         OptionWithAnnotation<std::string, DateFormatAnnotation> dateFormat{this, "DateFormat", _("Date Format ($DATE in macro)"), "%d/%m/%Y", {}, {}, DateFormatAnnotation()};
+
         SubConfigOption                                         macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
         SubConfigOption                                         customKeymap{this, "CustomKeymap", _("Custom Keymap"), "fcitx://config/addon/lotus/custom_keymap"};
-        SubConfigOption appRules{this, "AppRules", _("App Rules"), "fcitx://config/addon/lotus/app_rules"}; KeyListOption modeMenuKey{
-            this, "ModeMenuKey", _("Mode Menu Hotkey"), {Key("grave")}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};);
+        OptionWithAnnotation<std::string, IconThemeAnnotation>  iconTheme{this, "IconTheme", _("Icon Selection"), "Dark", {}, {}, IconThemeAnnotation()};);
 
 } // namespace fcitx
 

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -163,7 +163,7 @@ namespace fcitx {
      */
     struct IconThemeAnnotation : public StringListAnnotation {
         IconThemeAnnotation() {
-            list_ = {_("Automatically"), _("Light"), _("Dark"), _("Lotus")};
+            list_ = {_("Light"), _("Dark"), _("Lotus")};
         }
     };
 
@@ -236,7 +236,7 @@ namespace fcitx {
         Option<bool>                                                                freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
         Option<bool>                                           ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
         Option<bool>                                           fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        OptionWithAnnotation<std::string, IconThemeAnnotation> iconTheme{this, "IconTheme", _("Icon Selection"), "Automatically", {}, {}, IconThemeAnnotation()};
+        OptionWithAnnotation<std::string, IconThemeAnnotation> iconTheme{this, "IconTheme", _("Icon Selection"), "Dark", {}, {}, IconThemeAnnotation()};
         Option<bool>                                           enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
         Option<bool>                                           enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
         Option<bool> showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true}; Option<bool> showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -22,8 +22,6 @@
 #include <fcitx-utils/utf8.h>
 
 #include <atomic>
-#include <thread>
-#include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -65,20 +63,17 @@ namespace fcitx {
     }
 
     enum class IconChoice {
-        Auto,
         Light,
         Dark,
         Lotus
     };
 
     static IconChoice stringToIconChoice(const std::string& choice) {
-        if (choice == "Light")
-            return IconChoice::Light;
         if (choice == "Dark")
             return IconChoice::Dark;
         if (choice == "Lotus")
             return IconChoice::Lotus;
-        return IconChoice::Auto;
+        return IconChoice::Light;
     }
 
     static inline uintptr_t newMacroTable(const lotusMacroTable& macroTable) {
@@ -114,21 +109,6 @@ namespace fcitx {
     }
 
     LotusEngine::LotusEngine(Instance* instance) : instance_(instance), factory_([this](InputContext& ic) { return new LotusState(this, &ic); }) { //NOLINT
-        lastDarkMode_       = isDarkMode();
-        themeWatcherThread_ = std::thread([this]() {
-            while (!stopWatcher_.load(std::memory_order_relaxed)) {
-                std::this_thread::sleep_for(std::chrono::seconds(5));
-                if (stopWatcher_.load(std::memory_order_relaxed))
-                    break;
-                bool current = isDarkMode();
-                if (current != lastDarkMode_) {
-                    lastDarkMode_ = current;
-                    instance_->eventDispatcher().schedule(
-                        [this]() { instance_->userInterfaceManager().update(UserInterfaceComponent::StatusArea, instance_->lastFocusedInputContext()); });
-                }
-            }
-        });
-
         const char* desktop = std::getenv("XDG_CURRENT_DESKTOP");
         isGnome_            = (desktop != nullptr) && std::string(desktop).find("GNOME") != std::string::npos;
         // emptyCustomKeymap_.customKeymap is implicitly initialized to empty by fcitx::Option default value macro.
@@ -231,10 +211,6 @@ namespace fcitx {
     }
 
     LotusEngine::~LotusEngine() {
-        stopWatcher_.store(true, std::memory_order_release);
-        if (themeWatcherThread_.joinable()) {
-            themeWatcherThread_.join();
-        }
         stop_flag_monitor.store(true, std::memory_order_release);
         monitor_cv.notify_all();
         int fd = mouse_socket_fd.load(std::memory_order_acquire);
@@ -917,75 +893,6 @@ namespace fcitx {
         }
     }
 
-    bool LotusEngine::isDarkMode() const {
-        // 1. Environment variables (Fastest and often set in WMs/DEs)
-        const char* gtkTheme = std::getenv("GTK_THEME");
-        if (gtkTheme && std::string(gtkTheme).find("dark") != std::string::npos) {
-            return true;
-        }
-
-        const char* colorScheme = std::getenv("COLOR_SCHEME"); // Used by some modern WMs
-        if (colorScheme && std::string(colorScheme).find("dark") != std::string::npos) {
-            return true;
-        }
-
-        // 2. Check for GNOME/KDE/DE specific hints
-        const char* desktop = std::getenv("XDG_CURRENT_DESKTOP");
-        if (desktop) {
-            std::string ds = desktop;
-            if (ds.find("GNOME") != std::string::npos || ds.find("KDE") != std::string::npos) {
-                // In these DEs, we usually rely on portals or specific settings,
-                // but if GTK_THEME isn't set, we might need a fallback.
-                // For now, continue to file checks.
-            }
-        }
-
-        // 3. Heuristic: Check GTK settings files (Common for WMs like i3, sway, etc.)
-        static const char* gtkSettingsFiles[] = {"/gtk-4.0/settings.ini", "/gtk-3.0/settings.ini"};
-
-        const char*        home       = std::getenv("HOME");
-        const char*        configHome = std::getenv("XDG_CONFIG_HOME");
-        std::string        configBase = configHome ? configHome : (home ? (std::string(home) + "/.config") : "");
-
-        if (!configBase.empty()) {
-            // Check GTK settings files (Common for WMs like i3, sway, etc. and GNOME)
-            for (const char* suffix : gtkSettingsFiles) {
-                std::ifstream file(configBase + suffix);
-                if (file.is_open()) {
-                    std::string line;
-                    while (std::getline(file, line)) {
-                        auto pos = line.find_first_not_of(" \t");
-                        if (pos == std::string::npos || line[pos] == '#')
-                            continue;
-                        line = line.substr(pos);
-
-                        if (line.rfind("gtk-application-prefer-dark-theme=1", 0) == 0)
-                            return true;
-                        if (line.rfind("gtk-theme-name", 0) == 0 && line.find("dark") != std::string::npos)
-                            return true;
-                    }
-                }
-            }
-
-            // Check KDE settings files (kdeglobals)
-            std::ifstream kdeFile(configBase + "/kdeglobals");
-            if (kdeFile.is_open()) {
-                std::string line;
-                while (std::getline(kdeFile, line)) {
-                    auto pos = line.find_first_not_of(" \t");
-                    if (pos == std::string::npos || line[pos] == '[' || line[pos] == '#')
-                        continue;
-                    line = line.substr(pos);
-
-                    if (line.rfind("ColorScheme=", 0) == 0 && line.find("Dark") != std::string::npos)
-                        return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     std::string LotusEngine::subModeIconImpl(const InputMethodEntry& /*entry*/, InputContext& /*inputContext*/) {
         bool useBlackDefault = false;
         bool useLotusIcons   = false;
@@ -994,8 +901,7 @@ namespace fcitx {
             case IconChoice::Light: useBlackDefault = true; break;
             case IconChoice::Dark: useBlackDefault = false; break;
             case IconChoice::Lotus: useLotusIcons = true; break;
-            case IconChoice::Auto:
-            default: useBlackDefault = !isDarkMode(); break;
+            default: useBlackDefault = true; break;
         }
 
         std::string baseIconName;

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -22,6 +22,8 @@
 #include <fcitx-utils/utf8.h>
 
 #include <atomic>
+#include <thread>
+#include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -62,6 +64,23 @@ namespace fcitx {
         return isAppModeMenuReservedKey(hotkeySym) ? FcitxKey_f : hotkeySym;
     }
 
+    enum class IconChoice {
+        Auto,
+        Light,
+        Dark,
+        Lotus
+    };
+
+    static IconChoice stringToIconChoice(const std::string& choice) {
+        if (choice == "Light")
+            return IconChoice::Light;
+        if (choice == "Dark")
+            return IconChoice::Dark;
+        if (choice == "Lotus")
+            return IconChoice::Lotus;
+        return IconChoice::Auto;
+    }
+
     static inline uintptr_t newMacroTable(const lotusMacroTable& macroTable) {
         const auto&        macros = *macroTable.macros;
         std::vector<char*> charArray;
@@ -95,6 +114,21 @@ namespace fcitx {
     }
 
     LotusEngine::LotusEngine(Instance* instance) : instance_(instance), factory_([this](InputContext& ic) { return new LotusState(this, &ic); }) { //NOLINT
+        lastDarkMode_       = isDarkMode();
+        themeWatcherThread_ = std::thread([this]() {
+            while (!stopWatcher_.load(std::memory_order_relaxed)) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                if (stopWatcher_.load(std::memory_order_relaxed))
+                    break;
+                bool current = isDarkMode();
+                if (current != lastDarkMode_) {
+                    lastDarkMode_ = current;
+                    instance_->eventDispatcher().schedule(
+                        [this]() { instance_->userInterfaceManager().update(UserInterfaceComponent::StatusArea, instance_->lastFocusedInputContext()); });
+                }
+            }
+        });
+
         const char* desktop = std::getenv("XDG_CURRENT_DESKTOP");
         isGnome_            = (desktop != nullptr) && std::string(desktop).find("GNOME") != std::string::npos;
         // emptyCustomKeymap_.customKeymap is implicitly initialized to empty by fcitx::Option default value macro.
@@ -197,6 +231,10 @@ namespace fcitx {
     }
 
     LotusEngine::~LotusEngine() {
+        stopWatcher_.store(true, std::memory_order_release);
+        if (themeWatcherThread_.joinable()) {
+            themeWatcherThread_.join();
+        }
         stop_flag_monitor.store(true, std::memory_order_release);
         monitor_cv.notify_all();
         int fd = mouse_socket_fd.load(std::memory_order_acquire);
@@ -879,20 +917,99 @@ namespace fcitx {
         }
     }
 
-    std::string LotusEngine::subModeIconImpl(const InputMethodEntry& /*entry*/, InputContext& /*inputContext*/) {
-        if (!*config_.useLotusIcons) {
-            bool useBlack = *config_.useBlackDefaultIcons;
-            switch (realMode) {
-                case LotusMode::Off: return useBlack ? "fcitx-lotus-off-default-black" : "fcitx-lotus-off-default";
-                case LotusMode::Emoji: return useBlack ? "fcitx-lotus-emoji-default-black" : "fcitx-lotus-emoji-default";
-                default: return useBlack ? "fcitx-lotus-default-black" : "fcitx-lotus-default";
+    bool LotusEngine::isDarkMode() const {
+        // 1. Environment variables (Fastest and often set in WMs/DEs)
+        const char* gtkTheme = std::getenv("GTK_THEME");
+        if (gtkTheme && std::string(gtkTheme).find("dark") != std::string::npos) {
+            return true;
+        }
+
+        const char* colorScheme = std::getenv("COLOR_SCHEME"); // Used by some modern WMs
+        if (colorScheme && std::string(colorScheme).find("dark") != std::string::npos) {
+            return true;
+        }
+
+        // 2. Check for GNOME/KDE/DE specific hints
+        const char* desktop = std::getenv("XDG_CURRENT_DESKTOP");
+        if (desktop) {
+            std::string ds = desktop;
+            if (ds.find("GNOME") != std::string::npos || ds.find("KDE") != std::string::npos) {
+                // In these DEs, we usually rely on portals or specific settings,
+                // but if GTK_THEME isn't set, we might need a fallback.
+                // For now, continue to file checks.
             }
         }
-        switch (realMode) {
-            case LotusMode::Off: return "fcitx-lotus-off";
-            case LotusMode::Emoji: return "fcitx-lotus-emoji";
-            default: return "fcitx-lotus";
+
+        // 3. Heuristic: Check GTK settings files (Common for WMs like i3, sway, etc.)
+        static const char* gtkSettingsFiles[] = {"/gtk-4.0/settings.ini", "/gtk-3.0/settings.ini"};
+
+        const char*        home       = std::getenv("HOME");
+        const char*        configHome = std::getenv("XDG_CONFIG_HOME");
+        std::string        configBase = configHome ? configHome : (home ? (std::string(home) + "/.config") : "");
+
+        if (!configBase.empty()) {
+            // Check GTK settings files (Common for WMs like i3, sway, etc. and GNOME)
+            for (const char* suffix : gtkSettingsFiles) {
+                std::ifstream file(configBase + suffix);
+                if (file.is_open()) {
+                    std::string line;
+                    while (std::getline(file, line)) {
+                        auto pos = line.find_first_not_of(" \t");
+                        if (pos == std::string::npos || line[pos] == '#')
+                            continue;
+                        line = line.substr(pos);
+
+                        if (line.rfind("gtk-application-prefer-dark-theme=1", 0) == 0)
+                            return true;
+                        if (line.rfind("gtk-theme-name", 0) == 0 && line.find("dark") != std::string::npos)
+                            return true;
+                    }
+                }
+            }
+
+            // Check KDE settings files (kdeglobals)
+            std::ifstream kdeFile(configBase + "/kdeglobals");
+            if (kdeFile.is_open()) {
+                std::string line;
+                while (std::getline(kdeFile, line)) {
+                    auto pos = line.find_first_not_of(" \t");
+                    if (pos == std::string::npos || line[pos] == '[' || line[pos] == '#')
+                        continue;
+                    line = line.substr(pos);
+
+                    if (line.rfind("ColorScheme=", 0) == 0 && line.find("Dark") != std::string::npos)
+                        return true;
+                }
+            }
         }
+
+        return false;
+    }
+
+    std::string LotusEngine::subModeIconImpl(const InputMethodEntry& /*entry*/, InputContext& /*inputContext*/) {
+        bool useBlackDefault = false;
+        bool useLotusIcons   = false;
+
+        switch (stringToIconChoice(config_.iconTheme.value())) {
+            case IconChoice::Light: useBlackDefault = true; break;
+            case IconChoice::Dark: useBlackDefault = false; break;
+            case IconChoice::Lotus: useLotusIcons = true; break;
+            case IconChoice::Auto:
+            default: useBlackDefault = !isDarkMode(); break;
+        }
+
+        std::string baseIconName;
+        switch (realMode) {
+            case LotusMode::Off: baseIconName = "fcitx-lotus-off"; break;
+            case LotusMode::Emoji: baseIconName = "fcitx-lotus-emoji"; break;
+            default: baseIconName = "fcitx-lotus"; break;
+        }
+
+        if (useLotusIcons) {
+            return baseIconName;
+        }
+
+        return baseIconName + (useBlackDefault ? "-default-black" : "-default");
     }
 
     std::string LotusEngine::subModeLabelImpl(const InputMethodEntry& /*entry*/, InputContext& /*inputContext*/) {

--- a/src/lotus-engine.h
+++ b/src/lotus-engine.h
@@ -19,6 +19,8 @@
 #include "emoji.h"
 #include "lotus.h"
 #include <mutex>
+#include <thread>
+#include <atomic>
 #include <fcitx-config/iniparser.h>
 #include <fcitx/action.h>
 #include <fcitx/addonfactory.h>
@@ -213,6 +215,9 @@ namespace fcitx {
         std::unique_ptr<SimpleAction>              settingsAction_;
         std::vector<SimpleAction*>                 toggleActions_;
         std::vector<ScopedConnection>              connections_;
+        mutable bool                               lastDarkMode_ = false;
+        std::thread                                themeWatcherThread_;
+        std::atomic<bool>                          stopWatcher_{false};
         CGoObject                                  dictionary_;
         std::unordered_map<std::string, LotusMode> appRules_;
         std::string                                appRulesPath_;
@@ -323,6 +328,12 @@ namespace fcitx {
          * @return Name of current program
          */
         static std::string getProgramName(InputContext* ic);
+
+        /**
+         * @brief Checks if the system is in dark mode.
+         * @return True if dark mode is detected.
+         */
+        bool isDarkMode() const;
     };
 
     /**

--- a/src/lotus-engine.h
+++ b/src/lotus-engine.h
@@ -19,8 +19,6 @@
 #include "emoji.h"
 #include "lotus.h"
 #include <mutex>
-#include <thread>
-#include <atomic>
 #include <fcitx-config/iniparser.h>
 #include <fcitx/action.h>
 #include <fcitx/addonfactory.h>
@@ -215,9 +213,6 @@ namespace fcitx {
         std::unique_ptr<SimpleAction>              settingsAction_;
         std::vector<SimpleAction*>                 toggleActions_;
         std::vector<ScopedConnection>              connections_;
-        mutable bool                               lastDarkMode_ = false;
-        std::thread                                themeWatcherThread_;
-        std::atomic<bool>                          stopWatcher_{false};
         CGoObject                                  dictionary_;
         std::unordered_map<std::string, LotusMode> appRules_;
         std::string                                appRulesPath_;
@@ -328,12 +323,6 @@ namespace fcitx {
          * @return Name of current program
          */
         static std::string getProgramName(InputContext* ic);
-
-        /**
-         * @brief Checks if the system is in dark mode.
-         * @return True if dark mode is detected.
-         */
-        bool isDarkMode() const;
     };
 
     /**


### PR DESCRIPTION
Đợt thay đổi này thực hiện các cải tiến sau cho icon trạng thái:

**Gộp cấu hình**: Hợp nhất `useLotusIcons` và `useBlackDefaultIcons` thành một tùy chọn dropdown duy nhất: **Icon Selection**.
   - **Light/Dark**: Ghi đè thủ công theo ý người dùng.
   - **Lotus**: Sử dụng icon màu đặc trưng của Lotus.