### PR TITLE
feat: implement 3-state W2U toggle dropdown

### DIFF
--- a/bamboo/bamboo-c.go
+++ b/bamboo/bamboo-c.go
@@ -20,7 +20,7 @@ import (
 			const char *outputCharset;
 			bool modernStyle;
 			bool freeMarking;
-			bool w2u;
+			int w2u;
 			const char *timeFormat;
 			const char *dateFormat;
 		} FcitxBambooEngineOption;
@@ -117,12 +117,13 @@ func EngineSetOption(engine uintptr, option *C.FcitxBambooEngineOption) {
 		flags &= ^bamboo.EfreeToneMarking
 	}
 
-	if bool(option.w2u) {
+	if int(option.w2u) != 0 {
 		flags |= bamboo.Ew2uEnabled
 	} else {
 		flags &= ^bamboo.Ew2uEnabled
 	}
 	bambooEngine.preeditor.SetFlag(flags)
+	bambooEngine.preeditor.SetW2UMode(int(option.w2u))
 	bambooEngine.timeFormat = C.GoString(option.timeFormat)
 	bambooEngine.dateFormat = C.GoString(option.dateFormat)
 }

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -53,7 +53,7 @@ SETTINGS_MAP = {
     },
     SettingsCategory.TYPING: {
         "SPELLING & CORRECTIONS": ["SpellCheck", "AutoNonVnRestore", "DdFreeStyle"],
-        "TYPING OPTIONS": ["ModernStyle", "FreeMarking", "W2U", "FixUinputWithAck", "DoubleSpaceToPeriod", "AutoCapitalizeAfterPunctuation"],
+        "TYPING OPTIONS": ["W2U", "ModernStyle", "FreeMarking", "FixUinputWithAck", "DoubleSpaceToPeriod", "AutoCapitalizeAfterPunctuation"],
     },
     SettingsCategory.SHORTCUTS: {
         "SHORTCUTS": ["ModeMenuKey"],

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -130,11 +130,11 @@ namespace fcitx {
         int  w2u;
     };
 
-    inline std::string w2uEnumToString(int mode) {
+    inline std::string w2uEnumToString(W2UMode mode) {
         switch (mode) {
-            case 0: return "Disabled";
-            case 1: return "Middle-Only";
-            case 2: return "Everywhere";
+            case W2UMode::Disabled: return "Disabled";
+            case W2UMode::MiddleOnly: return "Middle-Only";
+            case W2UMode::Everywhere: return "Everywhere";
             default: return "Disabled";
         }
     }
@@ -151,7 +151,7 @@ namespace fcitx {
 
     struct W2UAnnotation : public StringListAnnotation {
         W2UAnnotation() {
-            list_ = {_("Disabled"), _("Middle-Only"), _("Everywhere")};
+            list_ = {"Disabled", "Middle-Only", "Everywhere"};
         }
     };
 

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -117,29 +117,30 @@ namespace fcitx {
     /**
      * @brief Annotation for input method selection with sub-config support.
      */
-    enum class W2UMode {
+    enum class W2UMode : std::uint8_t {
         Disabled   = 0,
-        MiddleOnly = 1,
+        NonStart   = 1,
         Everywhere = 2,
     };
 
     inline std::string w2uEnumToString(W2UMode mode) {
         switch (mode) {
             case W2UMode::Disabled: return "Disabled";
-            case W2UMode::MiddleOnly: return "Non-Start";
+            case W2UMode::NonStart: return "Non-Start";
             case W2UMode::Everywhere: return "Everywhere";
             default: return "Disabled";
         }
     }
 
     inline int w2uStringToEnum(const std::string& mode) {
+        W2UMode modeEnum = W2UMode::Disabled;
         if (mode == "Disabled")
-            return 0;
+            modeEnum = W2UMode::Disabled;
         if (mode == "Non-Start")
-            return 1;
+            modeEnum = W2UMode::NonStart;
         if (mode == "Everywhere")
-            return 2;
-        return 0;
+            modeEnum = W2UMode::Everywhere;
+        return static_cast<int>(modeEnum);
     }
 
     struct W2UAnnotation : public StringListAnnotation {

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -123,13 +123,6 @@ namespace fcitx {
         Everywhere = 2,
     };
 
-    struct FcitxBambooEngineOption {
-        bool freeMarking;
-        bool modernStyle;
-        bool autoCorrect;
-        int  w2u;
-    };
-
     inline std::string w2uEnumToString(W2UMode mode) {
         switch (mode) {
             case W2UMode::Disabled: return "Disabled";

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -117,6 +117,44 @@ namespace fcitx {
     /**
      * @brief Annotation for input method selection with sub-config support.
      */
+    enum class W2UMode {
+        Disabled   = 0,
+        MiddleOnly = 1,
+        Everywhere = 2,
+    };
+
+    struct FcitxBambooEngineOption {
+        bool freeMarking;
+        bool modernStyle;
+        bool autoCorrect;
+        int  w2u;
+    };
+
+    inline std::string w2uEnumToString(int mode) {
+        switch (mode) {
+            case 0: return "Disabled";
+            case 1: return "Middle-Only";
+            case 2: return "Everywhere";
+            default: return "Disabled";
+        }
+    }
+
+    inline int w2uStringToEnum(const std::string& mode) {
+        if (mode == "Disabled")
+            return 0;
+        if (mode == "Middle-Only")
+            return 1;
+        if (mode == "Everywhere")
+            return 2;
+        return 0;
+    }
+
+    struct W2UAnnotation : public StringListAnnotation {
+        W2UAnnotation() {
+            list_ = {_("Disabled"), _("Middle-Only"), _("Everywhere")};
+        }
+    };
+
     struct InputMethodAnnotation : public StringListAnnotation {
         /**
          * @brief Dumps description with sub-config paths.
@@ -234,16 +272,17 @@ namespace fcitx {
         Option<bool> spellCheck{this, "SpellCheck", _("Enable Spell Check"), true}; Option<bool> enableMacro{this, "EnableMacro", _("Enable Macro"), true};
         Option<bool> capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true}; Option<bool> autoCapitalizeAfterPunctuation{
             this, "AutoCapitalizeAfterPunctuation", _("Auto capitalize after sentence-ending punctuation (. ! ? Enter) (experimental)"), false};
-        Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
-        Option<bool> w2u{this, "W2U", _("Type w to Produce ư"), true}; Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
-        Option<bool>                                                                modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
-        Option<bool>                                                                freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
-        Option<bool> ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
-        Option<bool> fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        Option<bool> useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
+        Option<bool>                                     doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
+        OptionWithAnnotation<std::string, W2UAnnotation> w2u{this, "W2U", _("Type w to Produce ư"), "Disabled", {}, {}, W2UAnnotation()};
+        Option<bool>                                     autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Keys With Invalid Words"), true};
+        Option<bool>                                     modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
+        Option<bool>                                     freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
+        Option<bool>                                     ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Keys With Invalid Words Is On"), true};
+        Option<bool>                                     fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
+        Option<bool>                                     useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
 
-        Option<bool> enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
-        Option<bool> enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
+        Option<bool>                                     enableDictionary{this, "EnableDictionary", _("Enable Custom Dictionary"), false};
+        Option<bool>                                     enableCustomKeymap{this, "EnableCustomKeymap", _("Enable Custom Keymap"), false};
 
         Option<bool> showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true}; Option<bool> showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};
         Option<bool>                                                                                       showModeMinecraft{this, "ShowModeMinecraft", _("Show Minecraft"), true};

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -126,7 +126,7 @@ namespace fcitx {
     inline std::string w2uEnumToString(W2UMode mode) {
         switch (mode) {
             case W2UMode::Disabled: return "Disabled";
-            case W2UMode::MiddleOnly: return "Middle-Only";
+            case W2UMode::MiddleOnly: return "Non-Start";
             case W2UMode::Everywhere: return "Everywhere";
             default: return "Disabled";
         }
@@ -135,7 +135,7 @@ namespace fcitx {
     inline int w2uStringToEnum(const std::string& mode) {
         if (mode == "Disabled")
             return 0;
-        if (mode == "Middle-Only")
+        if (mode == "Non-Start")
             return 1;
         if (mode == "Everywhere")
             return 2;
@@ -144,7 +144,7 @@ namespace fcitx {
 
     struct W2UAnnotation : public StringListAnnotation {
         W2UAnnotation() {
-            list_ = {"Disabled", "Middle-Only", "Everywhere"};
+            list_ = {"Disabled", "Non-Start", "Everywhere"};
         }
     };
 

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -71,7 +71,7 @@ namespace fcitx {
             .outputCharset       = engine_->config().outputCharset->data(),
             .modernStyle         = *engine_->config().modernStyle,
             .freeMarking         = *engine_->config().freeMarking,
-            .w2u                 = *engine_->config().w2u,
+            .w2u                 = w2uStringToEnum(*engine_->config().w2u),
             .timeFormat          = engine_->config().timeFormat->data(),
             .dateFormat          = engine_->config().dateFormat->data(),
         };


### PR DESCRIPTION
Implement 3-state W2U choice in configuration (Disabled, Non-Start, Everywhere) with a 3rd-party-friendly dropdown menu in the Python GUI. This PR includes the engine submodule update and the synchronized C++/CGo bridge.