### PR TITLE
sửa lỗi syntax });); thừa trong lotus-config.h

### DIFF
--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -220,8 +220,7 @@ namespace fcitx {
 
         SubConfigOption                                          macroEditor{this, "MacroEditor", _("Macro"), "fcitx://config/addon/lotus/lotus-macro"};
         SubConfigOption                                          customKeymap{this, "CustomKeymap", _("Custom Keymap"), "fcitx://config/addon/lotus/custom_keymap"};
-        OptionWithAnnotation<IconTheme, IconThemeI18NAnnotation> iconTheme{this, "IconTheme", _("Icon Color"), IconTheme::Auto};);
-
+        OptionWithAnnotation<IconTheme, IconThemeI18NAnnotation> iconTheme{this, "IconTheme", _("Icon Color"), IconTheme::Auto};
 } // namespace fcitx
 
 #endif


### PR DESCRIPTION
Sửa lỗi syntax trong file `src/lotus-config.h` - dòng cuối của struct `lotusConfig` có `}););` thừa một dấu `)` và `;`.