### PR TITLE
determineMacroCase panic khi key rỗng

### DIFF
--- a/bamboo/fcitxbambooengine.go
+++ b/bamboo/fcitxbambooengine.go
@@ -64,10 +64,10 @@ const (
 )
 
 func determineMacroCase(str string) uint8 {
-	var chars = []rune(str)
-	if len(chars) == 0 {
+	if str == "" {
 		return VnCaseNoChange
 	}
+	var chars = []rune(str)
 	if unicode.IsLower(chars[0]) {
 		return VnCaseAllSmall
 	} else {

--- a/bamboo/fcitxbambooengine.go
+++ b/bamboo/fcitxbambooengine.go
@@ -65,6 +65,9 @@ const (
 
 func determineMacroCase(str string) uint8 {
 	var chars = []rune(str)
+	if len(chars) == 0 {
+		return VnCaseNoChange
+	}
 	if unicode.IsLower(chars[0]) {
 		return VnCaseAllSmall
 	} else {

--- a/server/lotus-server.cpp
+++ b/server/lotus-server.cpp
@@ -61,7 +61,6 @@ bool UinputDevice::initialize() {
     usetup.id.vendor  = 0x1234;
     usetup.id.product = 0x5678;
     strncpy(usetup.name, "Lotus-Uinput-Server", UINPUT_MAX_NAME_SIZE - 1);
-    usetup.name[UINPUT_MAX_NAME_SIZE - 1] = '\0';
 
     if (ioctl(fd, UI_DEV_SETUP, &usetup) < 0 || ioctl(fd, UI_DEV_CREATE) < 0) {
         return false;

--- a/server/lotus-server.cpp
+++ b/server/lotus-server.cpp
@@ -61,6 +61,7 @@ bool UinputDevice::initialize() {
     usetup.id.vendor  = 0x1234;
     usetup.id.product = 0x5678;
     strncpy(usetup.name, "Lotus-Uinput-Server", UINPUT_MAX_NAME_SIZE - 1);
+    usetup.name[UINPUT_MAX_NAME_SIZE - 1] = '\0';
 
     if (ioctl(fd, UI_DEV_SETUP, &usetup) < 0 || ioctl(fd, UI_DEV_CREATE) < 0) {
         return false;


### PR DESCRIPTION
- Go panic (`bamboo/fcitxbambooengine.go`) `determineMacroCase` truy cập `chars[0]` không có guard, crash ngay khi macro key là chuỗi rỗng. Thêm kiểm tra `len(chars) == 0` trả về `VnCaseNoChange`.
