### PR TITLE
feat(settings): allow clearing mode menu hotkey with Backspace/Delete

### DIFF
--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -237,7 +237,7 @@ class HotkeyCaptureWidget(QPushButton):
                 self.main_layout.addWidget(lbl)
         elif not self.current_key:
             lbl = QLabel(_("None"))
-            lbl.setStyleSheet("color: palette(mid);")
+            lbl.setStyleSheet("color: palette(window-text); opacity: 0.6;")
             self.main_layout.addWidget(lbl)
         else:
             parts = pretty_format_hotkey_parts(self.current_key)
@@ -254,6 +254,13 @@ class HotkeyCaptureWidget(QPushButton):
     def _handle_key_event(self, event):
         """Internal helper to process captured keys."""
         key_code = event.key()
+
+        # Backspace or Delete (without modifiers) clears the hotkey
+        if key_code in (Qt.Key_Backspace, Qt.Key_Delete) and not event.modifiers():
+            self.current_key = ""
+            self.setChecked(False)
+            self.textChanged.emit(self.current_key)
+            return
 
         # Escape cancels the recording
         if key_code == Qt.Key_Escape:

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -237,7 +237,14 @@ class HotkeyCaptureWidget(QPushButton):
                 self.main_layout.addWidget(lbl)
         elif not self.current_key:
             lbl = QLabel(_("None"))
-            lbl.setStyleSheet("color: palette(window-text); opacity: 0.6;")
+            lbl.setStyleSheet("color: palette(window-text);")
+            try:
+                from qtpy.QtWidgets import QGraphicsOpacityEffect
+                opacity_effect = QGraphicsOpacityEffect(lbl)
+                opacity_effect.setOpacity(0.6)
+                lbl.setGraphicsEffect(opacity_effect)
+            except ImportError:
+                pass
             self.main_layout.addWidget(lbl)
         else:
             parts = pretty_format_hotkey_parts(self.current_key)

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -201,8 +201,12 @@ class DynamicSettingsPage(QWidget):
 
         hotkey_str = val.get("0", "") if isinstance(val, dict) else ""
 
+        display_label = _(label)
+        if key == "ModeMenuKey":
+            display_label += " " + _("(press Backspace to None)")
+
         row_layout = QHBoxLayout()
-        row_layout.addWidget(QLabel(_(label)))
+        row_layout.addWidget(QLabel(display_label))
         row_layout.addStretch()
 
         hk_btn = HotkeyCaptureWidget(hotkey_str)

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -203,7 +203,7 @@ class DynamicSettingsPage(QWidget):
 
         display_label = _(label)
         if key == "ModeMenuKey":
-            display_label += " " + _("(press Backspace to None)")
+            display_label += " " + _("(press Backspace or Delete to clear)")
 
         row_layout = QHBoxLayout()
         row_layout.addWidget(QLabel(display_label))


### PR DESCRIPTION
### Description
This PR allows users to completely disable the 'Mode Menu Hotkey' by clearing it in the settings. This resolves conflicts in applications like Neovim where the grave key is frequently used.

### Changes
- **Settings GUI**:
  - HotkeyCaptureWidget now supports pressing Backspace or Delete to clear the hotkey.
  - The 'None' label now uses the system palette(window-text) with 0.6 opacity for better theme compatibility.
  - Added a visual guide (press Backspace to None) to the 'Mode Menu Hotkey' label in the Python settings page.

Resolves #242.
Cc: @nhktmdzhg, @Bix2llets