### PR TITLE
build: auto-detect openrc executable to avoid installing init script on systemd

### DIFF
--- a/.github/workflows/packaging-dev.yml
+++ b/.github/workflows/packaging-dev.yml
@@ -3,6 +3,7 @@ name: Test Packaging Build
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build-deb:

--- a/.github/workflows/packaging-dev.yml
+++ b/.github/workflows/packaging-dev.yml
@@ -3,7 +3,6 @@ name: Test Packaging Build
 on:
   push:
   pull_request:
-  workflow_dispatch:
 
 jobs:
   build-deb:

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_program(OPENRC_EXECUTABLE openrc)
+mark_as_advanced(OPENRC_EXECUTABLE)
 if(OPENRC_EXECUTABLE)
     set(INSTALL_OPENRC_DEFAULT ON)
 else()

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,4 +1,10 @@
-option(INSTALL_OPENRC "Install OpenRC script" On)
+find_program(OPENRC_EXECUTABLE openrc)
+if(OPENRC_EXECUTABLE)
+    set(INSTALL_OPENRC_DEFAULT ON)
+else()
+    set(INSTALL_OPENRC_DEFAULT OFF)
+endif()
+option(INSTALL_OPENRC "Install OpenRC script" ${INSTALL_OPENRC_DEFAULT})
 install(FILES fcitx5-lotus-server@.service
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 


### PR DESCRIPTION
When installing the generated .deb package on Ubuntu/Debian, insserv generates annoying warnings during any subsequent apt or dpkg package operations:

```
insserv: warning: script 'fcitx5-lotus' missing LSB tags
insserv: Default-Start undefined, assuming empty start runlevel(s) for script fcitx5-lotus'
insserv: Default-Stop  undefined, assuming empty stop runlevel(s) for script fcitx5-lotus'
```

This happens because the .deb package incorrectly includes the fcitx5-lotus.openrc script in /etc/init.d/fcitx5-lotus. This script is meant for OpenRC systems but is being installed on systemd-based distributions (like Ubuntu/Debian), causing insserv to complain about missing LSB tags.

Expected behavior The OpenRC script should only be installed on distributions that actually use OpenRC (like Alpine or Artix) and should be completely excluded from builds on systemd-based distributions (like the GitHub Actions CI runners for Debian/Ubuntu/Fedora/Arch).

Proposed Solution Instead of having INSTALL_OPENRC default to On, we can update misc/CMakeLists.txt to auto-detect if openrc is present on the build system