### PR TITLE
Add option to convert double hyphen to em-dash

### DIFF
--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -51,7 +51,7 @@ SETTINGS_MAP = {
     },
     SettingsCategory.TYPING: {
         "SPELLING & CORRECTIONS": ["SpellCheck", "AutoNonVnRestore", "DdFreeStyle"],
-        "TYPING OPTIONS": ["W2U", "ModernStyle", "FreeMarking", "FixUinputWithAck", "DoubleSpaceToPeriod", "AutoCapitalizeAfterPunctuation"],
+        "TYPING OPTIONS": ["W2U", "ModernStyle", "FreeMarking", "FixUinputWithAck", "DoubleSpaceToPeriod", "DoubleHyphenToEmDash", "AutoCapitalizeAfterPunctuation"],
     },
     SettingsCategory.SHORTCUTS: {
         "SHORTCUTS": ["ModeMenuKey"],

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -199,6 +199,7 @@ namespace fcitx {
         Option<bool> capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true}; Option<bool> autoCapitalizeAfterPunctuation{
             this, "AutoCapitalizeAfterPunctuation", _("Auto capitalize after sentence-ending punctuation (. ! ? Enter) (experimental)"), false};
         Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
+        Option<bool> doubleHyphenToEmDash{this, "DoubleHyphenToEmDash", _("Double Hyphen to Em-Dash (--)"), false};
         Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Invalid Words"), true};
         Option<bool> modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
         Option<bool> freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -864,6 +864,23 @@ namespace fcitx {
         }
     }
 
+    void LotusState::handleDoubleHyphenReplacement() {
+        const char* emDash = "\xe2\x80\x94"; // UTF-8 for em-dash (U+2014)
+        switch (realMode) {
+            case LotusMode::SurroundingText: {
+                ic_->deleteSurroundingText(-1, 1);
+                ic_->commitString(emDash);
+                LOTUS_INFO("Commit: — (em-dash)");
+                break;
+            }
+            default: { // Uinput, Smooth, Preedit, etc.
+                performReplacement("-", emDash);
+                LOTUS_INFO("Commit: — (em-dash)");
+                break;
+            }
+        }
+    }
+
     void LotusState::keyEvent(KeyEvent& keyEvent) {
         if (!lotusEngine_ || keyEvent.isRelease())
             return;
@@ -981,6 +998,20 @@ namespace fcitx {
             }
         }
 
+        if (*engine_->config().doubleHyphenToEmDash && realMode != LotusMode::Off) {
+            if (currentSym == FcitxKey_minus) {
+                if (isPrevHyphen_) {
+                    keyEvent.filterAndAccept();
+                    handleDoubleHyphenReplacement();
+                    isPrevHyphen_ = false;
+                    return;
+                }
+                isPrevHyphen_ = true;
+            } else {
+                isPrevHyphen_ = false;
+            }
+        }
+
         switch (realMode) {
             case LotusMode::Uinput:
             case LotusMode::Smooth:
@@ -1017,6 +1048,7 @@ namespace fcitx {
 
         if (lotusEngine_) {
             isPrevSpace_       = false;
+            isPrevHyphen_      = false;
             shouldCapitalize_  = false;
             isPrevPunctuation_ = false;
             if (realMode == LotusMode::Preedit && isFocusOut) {
@@ -1104,6 +1136,8 @@ namespace fcitx {
         emojiCandidates_.clear();
         buffered_keys_.clear();
         shouldCapitalize_  = false;
+        isPrevSpace_       = false;
+        isPrevHyphen_      = false;
         isPrevPunctuation_ = false;
         if (lotusEngine_)
             ResetEngine(lotusEngine_.handle());

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -985,7 +985,8 @@ namespace fcitx {
         }
 
         if (*engine_->config().doubleSpaceToPeriod && realMode != LotusMode::Off) {
-            if (currentSym == FcitxKey_space) {
+            bool isSpaceKey = (currentSym == FcitxKey_space || currentSym == FcitxKey_KP_Space);
+            if (isSpaceKey && !keyEvent.key().hasModifier()) {
                 if (isPrevSpace_) {
                     keyEvent.filterAndAccept();
                     handleDoubleSpaceReplacement();

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -865,7 +865,8 @@ namespace fcitx {
     }
 
     void LotusState::handleDoubleHyphenReplacement() {
-        const char* emDash = "\xe2\x80\x94"; // UTF-8 for em-dash (U+2014)
+        // Unicode U+2014 (em-dash) encoded in UTF-8: 0xE2 0x80 0x94
+        const char* emDash = "—"; // UTF-8 literal (same as "\xe2\x80\x94")
         switch (realMode) {
             case LotusMode::SurroundingText: {
                 ic_->deleteSurroundingText(-1, 1);

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -865,8 +865,8 @@ namespace fcitx {
     }
 
     void LotusState::handleDoubleHyphenReplacement() {
-        // Unicode U+2014 (em-dash) encoded in UTF-8: 0xE2 0x80 0x94
-        const char* emDash = "—"; // UTF-8 literal (same as "\xe2\x80\x94")
+        // Em-dash (U+2014)
+        const char* emDash = "—";
         switch (realMode) {
             case LotusMode::SurroundingText: {
                 ic_->deleteSurroundingText(-1, 1);

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -866,7 +866,7 @@ namespace fcitx {
 
     void LotusState::handleDoubleHyphenReplacement() {
         // Em-dash (U+2014)
-        const char* emDash = "—";
+        std::string emDash = "—";
         switch (realMode) {
             case LotusMode::SurroundingText: {
                 ic_->deleteSurroundingText(-1, 1);

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -999,7 +999,8 @@ namespace fcitx {
         }
 
         if (*engine_->config().doubleHyphenToEmDash && realMode != LotusMode::Off) {
-            if (currentSym == FcitxKey_minus) {
+            bool isHyphenKey = (currentSym == FcitxKey_minus || currentSym == FcitxKey_KP_Subtract);
+            if (isHyphenKey && !keyEvent.key().hasModifier()) {
                 if (isPrevHyphen_) {
                     keyEvent.filterAndAccept();
                     handleDoubleHyphenReplacement();

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -103,6 +103,7 @@ namespace fcitx {
         bool                    waitAck_ = false;
         std::vector<KeyEntry>   buffered_keys_; ///< Keystrokes buffered during replacement
         bool                    isPrevSpace_        = false;
+        bool                    isPrevHyphen_       = false;
         bool                    shouldCapitalize_   = false;
         bool                    isPrevPunctuation_  = false;
         int64_t                 lastDeactivateTime_ = 0;
@@ -177,6 +178,11 @@ namespace fcitx {
          * @brief Handles the double space to period replacement.
          */
         void handleDoubleSpaceReplacement();
+
+        /**
+         * @brief Handles the double hyphen to em-dash replacement.
+         */
+        void handleDoubleHyphenReplacement();
 
         /**
          * @brief Checks and forwards special keys.


### PR DESCRIPTION
Add DoubleHyphenToEmDash option following the same pattern as DoubleSpaceToPeriod.

When enabled and user types '--', it is replaced with em-dash (—, U+2014).

Changes:
- Add DoubleHyphenToEmDash config option
- Implement handleDoubleHyphenReplacement() in LotusState
- Track isPrevHyphen_ state for double keypress detection
- Support all input modes (SurroundingText, Uinput, Smooth, etc.)