### PR TITLE
fix: make App label read-only using setAuxDown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ refresh-contributor
 lotus-version.h
 # Logs
 *.log
-__pycache__/install.sh
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ refresh-contributor
 lotus-version.h
 # Logs
 *.log
-__pycache__/
+__pycache__/install.sh

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -487,15 +487,15 @@ namespace fcitx {
                 }
 
                 int cursorIndex = menuList->globalCursorIndex();
-                if (cursorIndex < 1 || cursorIndex >= totalSize) {
-                    cursorIndex = 1;
+                if (cursorIndex < 0 || cursorIndex >= totalSize) {
+                    cursorIndex = 0;
                 }
 
                 int nextIndex = cursorIndex + delta;
-                if (nextIndex < 1) {
+                if (nextIndex < 0) {
                     nextIndex = totalSize - 1;
                 } else if (nextIndex >= totalSize) {
-                    nextIndex = 1;
+                    nextIndex = 0;
                 }
 
                 menuList->setGlobalCursorIndex(nextIndex);
@@ -527,8 +527,8 @@ namespace fcitx {
                 case FcitxKey_Return: {
                     if (menuList && !menuList->empty()) {
                         int selectedIndex = menuList->globalCursorIndex();
-                        if (selectedIndex < 1 || selectedIndex >= menuList->totalSize()) {
-                            selectedIndex = 1;
+                        if (selectedIndex < 0 || selectedIndex >= menuList->totalSize()) {
+                            selectedIndex = 0;
                         }
                         menuList->candidateFromAll(selectedIndex).select(ic);
                         return;
@@ -871,7 +871,7 @@ namespace fcitx {
         allModes.push_back({defaultMode, _("Default Typing"), FcitxKey_r, *config_.showModeDefault}); // Add reset option
 
         int activeSelectionIdx  = -1;
-        int currentCandidateIdx = 1;
+        int currentCandidateIdx = 0;
 
         modeMenuMapping_.clear();
 
@@ -917,8 +917,8 @@ namespace fcitx {
 
         if (activeSelectionIdx != -1) {
             candidateList->setGlobalCursorIndex(activeSelectionIdx);
-        } else if (candidateList->totalSize() > 1) {
-            candidateList->setGlobalCursorIndex(1);
+        } else if (candidateList->totalSize() > 0) {
+            candidateList->setGlobalCursorIndex(0);
         }
 
         ic->inputPanel().reset();

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -870,8 +870,6 @@ namespace fcitx {
         const LotusMode defaultMode = config_.mode.value();
         allModes.push_back({defaultMode, _("Default Typing"), FcitxKey_r, *config_.showModeDefault}); // Add reset option
 
-        candidateList->append(std::make_unique<DisplayOnlyCandidateWord>(Text(_("App: ") + currentConfigureApp_)));
-
         int activeSelectionIdx  = -1;
         int currentCandidateIdx = 1;
 
@@ -925,6 +923,7 @@ namespace fcitx {
 
         ic->inputPanel().reset();
         ic->inputPanel().setCandidateList(std::move(candidateList));
+        ic->inputPanel().setAuxDown(Text(_("App: ") + currentConfigureApp_));
         ic->updateUserInterface(UserInterfaceComponent::InputPanel);
     }
 


### PR DESCRIPTION
## Summary
- Change "App: [appname]" from selectable candidate to read-only auxiliary text
- Use `setAuxDown()` like "Page X/Y" label does
- Prevents hovering/selecting the App label in mode menu

## Changes
- `src/lotus-engine.cpp`: Move App label display from `candidateList->append()` to `ic->inputPanel().setAuxDown()`

## Testing
- [x] Build passes
- [x] App label shows but cannot be selected/hovered
- [x] Behaves like "Page X/Y" read-only text