### PR TITLE
Update flake.lock and fix build issues with extra-cmake-modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {

--- a/nix/packages/fcitx5-lotus/default.nix
+++ b/nix/packages/fcitx5-lotus/default.nix
@@ -42,12 +42,13 @@ stdenv.mkDerivation rec {
     fcitx5
     libinput
     libx11
-    (python3.withPackages (ps:
-      with ps; [
+    (python3.withPackages (
+      ps: with ps; [
         pyqt6
         dbus-python
         qtpy
-      ]))
+      ]
+    ))
     qt6.qtbase
     udev
   ];

--- a/nix/packages/fcitx5-lotus/default.nix
+++ b/nix/packages/fcitx5-lotus/default.nix
@@ -3,12 +3,12 @@
   stdenv,
   buildGoModule,
   cmake,
-  extra-cmake-modules,
   fcitx5,
   fetchFromGitHub,
   gettext,
   go,
   hicolor-icon-theme,
+  kdePackages,
   libinput,
   libx11,
   pkg-config,
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
+    kdePackages.extra-cmake-modules
     gettext
     go
     hicolor-icon-theme


### PR DESCRIPTION
Lỗi build không tìm thấy `extra-cmake-modules` trên branch unstable mới nhất của NixOS.

Giải pháp: dùng `extra-cmake-modules` từ `kdePackages` group thay cho `extra-cmake-modules` cũ.