### PR TITLE
feat: add cycle mode shortcuts and UI refinements

### DIFF
--- a/po/fcitx5-lotus.pot
+++ b/po/fcitx5-lotus.pot
@@ -780,3 +780,48 @@ msgstr ""
 #: settings-gui/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop.in:3
 msgid "Configure Fcitx5 Lotus Input Method"
 msgstr ""
+
+msgid "Shortcut for Uinput (Smooth)"
+msgstr ""
+
+msgid "Shortcut for Uinput (Slow)"
+msgstr ""
+
+msgid "Shortcut for Uinput (Super Smooth)"
+msgstr ""
+
+msgid "Shortcut for Minecraft"
+msgstr ""
+
+msgid "Shortcut for Surrounding Text"
+msgstr ""
+
+msgid "Shortcut for Preedit"
+msgstr ""
+
+msgid "Shortcut for Emoji Picker"
+msgstr ""
+
+msgid "Shortcut for OFF"
+msgstr ""
+
+msgid "Shortcut for Default Typing"
+msgstr ""
+
+msgid "MAIN SHORTCUTS"
+msgstr ""
+
+msgid "MODE SWITCHING"
+msgstr ""
+
+msgid "Shortcuts"
+msgstr ""
+
+msgid "Cannot Save"
+msgstr ""
+
+msgid "Duplicate mode shortcut: {shortcut} is used by {modes}."
+msgstr ""
+
+msgid "Duplicate shortcut: {shortcut}"
+msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -802,3 +802,97 @@ msgstr "Cài đặt Fcitx5 Lotus"
 #: settings-gui/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop.in:3
 msgid "Configure Fcitx5 Lotus Input Method"
 msgstr "Tuỳ chỉnh bộ gõ Fcitx5 Lotus"
+
+msgid "Shortcut for Uinput (Smooth)"
+msgstr "Phím tắt cho Uinput (Mượt)"
+
+msgid "Shortcut for Uinput (Slow)"
+msgstr "Phím tắt cho Uinput (Chậm)"
+
+msgid "Shortcut for Uinput (Super Smooth)"
+msgstr "Phím tắt cho Uinput (Siêu mượt)"
+
+msgid "Shortcut for Minecraft"
+msgstr "Phím tắt cho Minecraft"
+
+msgid "Shortcut for Surrounding Text"
+msgstr "Phím tắt cho Văn bản xung quanh"
+
+msgid "Shortcut for Preedit"
+msgstr "Phím tắt cho Gạch chân"
+
+msgid "Shortcut for Emoji Picker"
+msgstr "Phím tắt cho Chọn Emoji"
+
+msgid "Shortcut for OFF"
+msgstr "Phím tắt cho Tắt"
+
+msgid "Shortcut for Default Typing"
+msgstr "Phím tắt cho Chế độ gõ mặc định"
+
+msgid "MAIN SHORTCUTS"
+msgstr "PHÍM TẮT CHÍNH"
+
+msgid "MODE SWITCHING"
+msgstr "CHUYỂN CHẾ ĐỘ GÕ"
+
+msgid "Shortcuts"
+msgstr "Phím tắt"
+
+msgid "Cannot Save"
+msgstr "Không thể lưu"
+
+msgid "Duplicate mode shortcut: {shortcut} is used by {modes}."
+msgstr "Phím chuyển chế độ bị trùng: {shortcut} đang được dùng bởi {modes}."
+
+msgid "Duplicate shortcut: {shortcut}"
+msgstr "Phím tắt bị trùng: {shortcut}"
+
+msgid "[ Press Key... ]"
+msgstr "[ Nhấn phím... ]"
+
+msgid "Configure basic input method settings and behaviors."
+msgstr "Thiết lập các cài đặt và hành vi cơ bản của bộ gõ."
+
+msgid "Customize the look and feel of the Lotus status icons and theme."
+msgstr "Tùy chỉnh giao diện, biểu tượng trạng thái và chủ đề của Lotus."
+
+msgid "Fine-tune spelling corrections and advanced typing options."
+msgstr "Tinh chỉnh kiểm tra chính tả và các tùy chọn gõ nâng cao."
+
+msgid "Manage input mode shortcuts and their display order."
+msgstr "Quản lý phím tắt cho các chế độ gõ và thứ tự hiển thị của chúng."
+
+msgid "System-wide hotkeys for menu and mode selection."
+msgstr "Phím tắt toàn hệ thống để mở menu và chọn nhanh chế độ."
+
+msgid "Basic engine configuration and character sets."
+msgstr "Cấu hình bộ gõ cơ bản và bảng mã ký tự."
+
+msgid "Common typing behaviors and transformations."
+msgstr "Các hành vi gõ phím và chuyển đổi ký tự phổ biến."
+
+msgid "Visual appearance of the status area icons."
+msgstr "Giao diện hiển thị của các biểu tượng trên vùng trạng thái."
+
+msgid "Manage how the engine handles spelling and word restoration."
+msgstr "Quản lý cách bộ gõ xử lý chính tả và khôi phục từ."
+
+msgid "Advanced text processing and auto-correction features."
+msgstr "Các tính năng xử lý văn bản và tự động sửa lỗi nâng cao."
+
+msgid "Enable/disable input modes and assign single-key shortcuts."
+msgstr "Bật/tắt các chế độ gõ và gán phím tắt nhanh bằng một ký tự."
+
+msgid "Drag the handle on the left to reorder modes in the menu. Use checkboxes to toggle visibility, and click the buttons to reassign shortcuts."
+msgstr "Kéo thả biểu tượng bên trái để sắp xếp thứ tự chế độ trong menu. Đánh dấu để bật/tắt hiển thị, và nhấn vào các nút để gán lại phím tắt."
+
+msgid "Cycle Mode Hotkey"
+msgstr "Phím tắt chuyển nhanh chế độ"
+
+msgid "Manage input mode shortcuts, display order, and fast cycling."
+msgstr "Quản lý phím tắt, thứ tự hiển thị và chuyển nhanh các chế độ gõ."
+
+msgid "Assign hotkeys to open the mode menu or quickly cycle through enabled modes."
+msgstr "Gán phím tắt để mở menu chế độ hoặc chuyển nhanh giữa các chế độ đang bật."
+

--- a/settings-gui/ui/components.py
+++ b/settings-gui/ui/components.py
@@ -373,3 +373,56 @@ class HotkeyCaptureWidget(QPushButton):
             if val in self.record_mods:
                 self.record_mods.remove(val)
                 self._update_display()
+
+
+class SingleKeyCaptureWidget(HotkeyCaptureWidget):
+    """A version of HotkeyCaptureWidget that only captures a single key (no modifiers)."""
+
+    def _update_display(self):
+        self._clear_layout()
+        
+        if self.isChecked():
+            lbl = QLabel(_("[ Press Key... ]"))
+            lbl.setStyleSheet("color: palette(highlight); font-weight: bold;")
+            self.main_layout.addWidget(lbl)
+        elif not self.current_key:
+            lbl = QLabel(_("None"))
+            lbl.setStyleSheet("color: palette(mid);")
+            self.main_layout.addWidget(lbl)
+        else:
+            # For single key, we just show it directly or via map
+            display_text = HOTKEY_SYM_MAP.get(self.current_key, self.current_key.capitalize())
+            cap = KeyCap(display_text)
+            self.main_layout.addWidget(cap)
+
+    def _handle_key_event(self, event):
+        key_code = event.key()
+
+        # Escape cancels
+        if key_code == Qt.Key_Escape:
+            self.setChecked(False)
+            return
+
+        # Ignore standalone modifier keys
+        if key_code in (Qt.Key_Control, Qt.Key_Shift, Qt.Key_Alt, Qt.Key_Meta):
+            return
+
+        if key_code == Qt.Key_unknown:
+            return
+
+        # Capture base key only
+        keysym = event.nativeVirtualKey()
+        base_key = ""
+
+        if libxkb and keysym > 0:
+            buf = ctypes.create_string_buffer(64)
+            if libxkb.xkb_keysym_get_name(keysym, buf, 64) > 0:
+                base_key = buf.value.decode("utf-8")
+
+        if not base_key:
+            base_key = event.text() if event.text() and event.text().isprintable() else QKeySequence(key_code).toString()
+
+        if base_key:
+            self.current_key = base_key
+            self.setChecked(False)
+            self.textChanged.emit(self.current_key)

--- a/settings-gui/ui/main_window.py
+++ b/settings-gui/ui/main_window.py
@@ -74,6 +74,10 @@ class LotusSettingsWindow(QMainWindow):
                 font-weight: bold;
                 font-family: monospace;
             }
+            QLabel#ShortcutWarning {
+                color: palette(link-visited);
+                font-size: 12px;
+            }
         """)
 
     def _setup_ui(self):
@@ -195,6 +199,11 @@ class LotusSettingsWindow(QMainWindow):
             KeymapEditorPage(self.dbus_handler),
         )
         self._add_page(
+            _("Shortcuts"),
+            "preferences-desktop-keyboard-shortcuts",
+            DynamicSettingsPage(self.dbus_handler, category=SettingsCategory.SHORTCUTS),
+        )
+        self._add_page(
             _("Appearance"),
             "preferences-desktop-theme",
             DynamicSettingsPage(
@@ -239,16 +248,46 @@ class LotusSettingsWindow(QMainWindow):
             and self.content_stack.widget(i).is_modified()
             for i in range(self.content_stack.count())
         )
-        self.btn_apply.setEnabled(any_modified)
+        has_errors = self.has_validation_errors()
+        self.btn_apply.setEnabled(any_modified and not has_errors)
         self.btn_cancel.setEnabled(any_modified)
+        self.btn_ok.setEnabled(not has_errors)
         self.update_reset_button_state()
+
+    def has_validation_errors(self):
+        return any(
+            hasattr(self.content_stack.widget(i), "has_validation_errors")
+            and self.content_stack.widget(i).has_validation_errors()
+            for i in range(self.content_stack.count())
+        )
+
+    def validation_message(self):
+        messages = []
+        for i in range(self.content_stack.count()):
+            page = self.content_stack.widget(i)
+            if hasattr(page, "validation_message"):
+                message = page.validation_message()
+                if message:
+                    messages.append(message)
+        return "\n".join(messages)
 
     def on_save_all(self, quiet=False):
         """Triggers save on all pages that support it."""
+        if self.has_validation_errors():
+            from qtpy.QtWidgets import QMessageBox
+
+            QMessageBox.warning(
+                self,
+                _("Cannot Save"),
+                self.validation_message(),
+            )
+            return False
+
         for i in range(self.content_stack.count()):
             page = self.content_stack.widget(i)
             if hasattr(page, "save_data"):
-                page.save_data()
+                if page.save_data() is False:
+                    return False
 
         self.btn_apply.setEnabled(False)
         self.btn_cancel.setEnabled(False)
@@ -259,10 +298,11 @@ class LotusSettingsWindow(QMainWindow):
             QMessageBox.information(
                 self, _("Success"), _("Settings saved.")
             )
+        return True
 
     def on_ok(self):
-        self.on_save_all(quiet=True)
-        self.close()
+        if self.on_save_all(quiet=True):
+            self.close()
 
     def on_cancel(self):
         """Discards all unsaved changes by reloading data on all pages."""
@@ -275,6 +315,7 @@ class LotusSettingsWindow(QMainWindow):
 
         self.btn_apply.setEnabled(False)
         self.btn_cancel.setEnabled(False)
+        self.btn_ok.setEnabled(not self.has_validation_errors())
         self.update_reset_button_state()
 
     def _on_sidebar_changed(self, index):

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -614,10 +614,16 @@ class DynamicSettingsPage(QWidget):
         finally:
             self.blockSignals(False)
 
+    def has_validation_errors(self):
+        self._validate_mode_shortcuts()
+        return bool(self.validation_errors)
+
+    def validation_message(self):
+        return "\n".join(self.validation_errors)
+
     def save_data(self):
         """Commits all staged changes to DBus."""
-        self._validate_mode_shortcuts()
-        if self.validation_errors:
+        if self.has_validation_errors():
             return False
 
         if not self.modified_values:
@@ -636,11 +642,12 @@ class DynamicSettingsPage(QWidget):
         """Updates internal state and notifies parent window of change."""
         self.modified_values[key] = new_value
         self.current_values[key] = new_value
-        # Notify the parent window (LotusSettingsWindow) if it exists
-        main_win = self.window()
-        if hasattr(main_win, "on_changed"):
-            main_win.on_changed()
 
         # Real-time validation if it's a shortcut
         if key in MODE_SHORTCUT_KEYS or key in MODE_SHORTCUT_TO_VISIBILITY.values():
             self._validate_mode_shortcuts()
+
+        # Notify the parent window (LotusSettingsWindow) if it exists
+        main_win = self.window()
+        if hasattr(main_win, "on_changed"):
+            main_win.on_changed()

--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -11,11 +11,19 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QCheckBox,
     QLabel,
+    QLineEdit,
     QScrollArea,
     QFrame,
     QComboBox,
 )
-from ui.components import HotkeyEditorWidget, HelpIcon
+from qtpy.QtCore import Qt, QSize, QTimer
+from qtpy.QtGui import QIcon
+from ui.components import (
+    HotkeyEditorWidget,
+    HelpIcon,
+    pretty_format_hotkey_parts,
+    SingleKeyCaptureWidget,
+)
 from ui.helpers import HELPERS, add_help_icon
 from core.dbus_handler import LotusDBusHandler
 from enum import Enum
@@ -33,31 +41,84 @@ class SettingsCategory(Enum):
 # Mapping of settings keys to categories and groups
 SETTINGS_MAP = {
     SettingsCategory.GENERAL: {
-        "HOTKEYS": ["ModeMenuKey"],
         "INPUT METHOD": ["InputMethod", "Mode", "OutputCharset"],
-        "LOADABLE MODES": [
-            "ShowModeSmooth",
-            "ShowModeUinput",
-            "ShowModeSuperSmooth",
-            "ShowModeMinecraft",
-            "ShowModeSurroundingText",
-            "ShowModePreedit",
-            "ShowModeEmoji",
-            "ShowModeOff",
-            "ShowModeDefault",
-        ],
+        "TYPING": ["W2U", "BracketTransform"],
     },
     SettingsCategory.APPEARANCE: {
         "THEME & ICONS": ["UseLotusIcons", "IconTheme"],
     },
     SettingsCategory.TYPING: {
         "SPELLING & CORRECTIONS": ["SpellCheck", "AutoNonVnRestore", "DdFreeStyle"],
-        "TYPING OPTIONS": ["W2U", "BracketTransform", "ModernStyle", "FreeMarking", "FixUinputWithAck", "DoubleSpaceToPeriod", "DoubleHyphenToEmDash", "AutoCapitalizeAfterPunctuation"],
+        "TYPING OPTIONS": [
+            "ModernStyle",
+            "FreeMarking",
+            "FixUinputWithAck",
+            "DoubleSpaceToPeriod",
+            "DoubleHyphenToEmDash",
+            "AutoCapitalizeAfterPunctuation",
+        ],
     },
     SettingsCategory.SHORTCUTS: {
-        "SHORTCUTS": ["ModeMenuKey"],
-    }
+        "MAIN SHORTCUTS": ["ModeMenuKey", "CycleModeKey"],
+        "MODE SWITCHING": [
+            "ShortcutSmooth",
+            "ShortcutUinput",
+            "ShortcutSuperSmooth",
+            "ShortcutMinecraft",
+            "ShortcutSurroundingText",
+            "ShortcutPreedit",
+            "ShortcutEmoji",
+            "ShortcutOff",
+            "ShortcutDefault",
+        ],
+    },
 }
+
+CATEGORY_DESCRIPTIONS = {
+    SettingsCategory.GENERAL: _("Configure basic input method settings and behaviors."),
+    SettingsCategory.APPEARANCE: _(
+        "Customize the look and feel of the Lotus status icons and theme."
+    ),
+    SettingsCategory.TYPING: _(
+        "Fine-tune spelling corrections and advanced typing options."
+    ),
+    SettingsCategory.SHORTCUTS: _(
+        "Manage input mode shortcuts, display order, and fast cycling."
+    ),
+}
+
+GROUP_DESCRIPTIONS = {
+    "MAIN SHORTCUTS": _(
+        "Assign hotkeys to open the mode menu or quickly cycle through enabled modes."
+    ),
+}
+
+
+MODE_SHORTCUT_TO_VISIBILITY = {
+    "ShortcutSmooth": "ShowModeSmooth",
+    "ShortcutUinput": "ShowModeUinput",
+    "ShortcutSuperSmooth": "ShowModeSuperSmooth",
+    "ShortcutMinecraft": "ShowModeMinecraft",
+    "ShortcutSurroundingText": "ShowModeSurroundingText",
+    "ShortcutPreedit": "ShowModePreedit",
+    "ShortcutEmoji": "ShowModeEmoji",
+    "ShortcutOff": "ShowModeOff",
+    "ShortcutDefault": "ShowModeDefault",
+}
+
+MODE_KEY_TO_INTERNAL_NAME = {
+    "ShortcutSmooth": "Smooth",
+    "ShortcutUinput": "Uinput",
+    "ShortcutSuperSmooth": "SuperSmooth",
+    "ShortcutMinecraft": "Minecraft",
+    "ShortcutSurroundingText": "SurroundingText",
+    "ShortcutPreedit": "Preedit",
+    "ShortcutEmoji": "Emoji",
+    "ShortcutOff": "Off",
+    "ShortcutDefault": "Default",
+}
+
+MODE_SHORTCUT_KEYS = list(MODE_SHORTCUT_TO_VISIBILITY.keys())
 
 
 class CardWidget(QFrame):
@@ -82,7 +143,12 @@ class CardWidget(QFrame):
 
 
 class DynamicSettingsPage(QWidget):
-    def __init__(self, dbus_handler: LotusDBusHandler, category: SettingsCategory = SettingsCategory.GENERAL, parent=None):
+    def __init__(
+        self,
+        dbus_handler: LotusDBusHandler,
+        category: SettingsCategory = SettingsCategory.GENERAL,
+        parent=None,
+    ):
         super().__init__(parent)
         self.dbus = dbus_handler
         self.category = category
@@ -90,9 +156,32 @@ class DynamicSettingsPage(QWidget):
         self.initial_values = {}
         self.modified_values = {}
         self.button_groups = []
+        self.shortcut_labels = {}
+        self.shortcut_warning_labels = {}
+        self.validation_errors = []
+        self.list_widgets = []  # Track list widgets for layout refresh
 
         self._setup_ui()
         self.load_config()
+
+    def showEvent(self, event):
+        """Force layout refresh when page becomes visible to fix initialization overflow."""
+        super().showEvent(event)
+        QTimer.singleShot(0, self._refresh_list_layouts)
+
+    def _refresh_list_layouts(self):
+        """Recalculate heights for all QListWidgets once the window has final dimensions."""
+        for lw in self.list_widgets:
+            total_h = 0
+            for i in range(lw.count()):
+                item = lw.item(i)
+                widget = lw.itemWidget(item)
+                if widget:
+                    h = widget.sizeHint().height()
+                    item.setSizeHint(QSize(100, h))
+                    total_h += h + 4
+            lw.setFixedHeight(total_h + 15)
+            lw.update()
 
     def _setup_ui(self):
         self.layout = QVBoxLayout(self)
@@ -119,10 +208,15 @@ class DynamicSettingsPage(QWidget):
                     item.widget().deleteLater()
             self.button_groups.clear()
             self.modified_values.clear()
+            self.shortcut_labels.clear()
+            self.shortcut_warning_labels.clear()
+            self.list_widgets.clear()
 
             config_data = self.dbus.get_config()
             if not config_data:
-                self.container_layout.addWidget(QLabel(_("Failed to load configuration.")))
+                self.container_layout.addWidget(
+                    QLabel(_("Failed to load configuration."))
+                )
                 return
 
             self.current_values = config_data.get("values", {})
@@ -142,6 +236,15 @@ class DynamicSettingsPage(QWidget):
             title.setObjectName("CategoryTitle")
             self.container_layout.addWidget(title)
 
+            # Add category description
+            desc_text = CATEGORY_DESCRIPTIONS.get(self.category)
+            if desc_text:
+                desc = QLabel(desc_text)
+                desc.setObjectName("CategoryDescription")
+                desc.setWordWrap(True)
+                desc.setStyleSheet("color: gray; font-size: 13px; margin-bottom: 10px;")
+                self.container_layout.addWidget(desc)
+
             category_groups = SETTINGS_MAP.get(self.category, {})
             for group_name, keys in category_groups.items():
                 # Convert ALL CAPS to Title Case
@@ -149,28 +252,48 @@ class DynamicSettingsPage(QWidget):
                 header = QLabel(_(header_text))
                 header.setObjectName("GroupHeader")
                 self.container_layout.addWidget(header)
-                
+
+                if group_name == "MODE SWITCHING":
+                    # Add specific instructions for mode switching
+                    mode_info = QLabel(
+                        _(
+                            "Drag the handle on the left to reorder modes in the menu. Use checkboxes to toggle visibility, and click the buttons to reassign shortcuts."
+                        )
+                    )
+                    mode_info.setWordWrap(True)
+                    mode_info.setStyleSheet(
+                        "color: gray; font-size: 13px; margin-bottom: 5px;"
+                    )
+                    self.container_layout.addWidget(mode_info)
+
+                    self._render_mode_list(card_layout=self.container_layout)
+                    continue
+
                 card = CardWidget("")
                 found_any = False
                 for k in keys:
                     item = self.all_metadata.get(k)
                     if not item:
                         continue
-                    
+
                     found_any = True
                     type_str = item[1]
-                    if k == "ModeMenuKey" or type_str == "Hotkey":
+                    if k in ["ModeMenuKey", "CycleModeKey"] or type_str == "Hotkey":
                         self._render_hotkey(item, card.content_layout)
                     elif "Enum" in item[4]:
                         self._render_combobox(item, card.content_layout)
                     elif type_str == "Boolean":
                         self._render_checkbox(item, card.content_layout)
-                
+                    elif type_str == "String":
+                        self._render_string(item, card.content_layout)
+
                 if found_any:
                     self.container_layout.addWidget(card)
 
             if self.category == SettingsCategory.INTERFACE and not category_groups:
-                self.container_layout.addWidget(QLabel(_("No interface settings available yet.")))
+                self.container_layout.addWidget(
+                    QLabel(_("No interface settings available yet."))
+                )
 
             self.initial_values = self.current_values.copy()
             self.container_layout.addStretch()
@@ -267,6 +390,206 @@ class DynamicSettingsPage(QWidget):
         row_layout.addStretch()
         layout.addLayout(row_layout)
 
+    def _render_string(self, item, layout):
+        key, type_str, label, default, annotations = item
+        val = str(self.current_values.get(key, default))
+
+        wrapper = QVBoxLayout()
+        wrapper.setSpacing(2)
+        wrapper.setContentsMargins(0, 0, 0, 0)
+
+        row_layout = QHBoxLayout()
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(8)
+
+        # If it's a shortcut key, add the corresponding visibility checkbox
+        if key in MODE_SHORTCUT_TO_VISIBILITY:
+            visibility_key = MODE_SHORTCUT_TO_VISIBILITY[key]
+            visibility_val = self.current_values.get(visibility_key, "True")
+
+            cb = QCheckBox()
+            cb.setChecked(str(visibility_val).lower() == "true")
+            cb.toggled.connect(
+                lambda checked, k=visibility_key: self.update_config(
+                    k, "True" if checked else "False"
+                )
+            )
+            row_layout.addWidget(cb)
+
+        label_widget = QLabel(_(label))
+        row_layout.addWidget(label_widget)
+        row_layout.addStretch()
+
+        if key in MODE_SHORTCUT_KEYS:
+            # Use single key capture for shortcuts
+            capture_btn = SingleKeyCaptureWidget(val)
+            capture_btn.setFixedWidth(100)
+            capture_btn.textChanged.connect(
+                lambda text, k=key: self.update_config(k, text)
+            )
+            row_layout.addWidget(capture_btn)
+        else:
+            edit = QLineEdit(val)
+            edit.setFixedWidth(56)
+            edit.setMaxLength(1)
+            edit.setPlaceholderText("-")
+            edit.textChanged.connect(lambda text, k=key: self.update_config(k, text))
+            row_layout.addWidget(edit)
+
+        wrapper.addLayout(row_layout)
+
+        if key in MODE_SHORTCUT_KEYS:
+            warning = QLabel()
+            warning.setObjectName("ShortcutWarning")
+            warning.setWordWrap(True)
+            warning.hide()
+            wrapper.addWidget(warning)
+            self.shortcut_labels[key] = label_widget
+            self.shortcut_warning_labels[key] = warning
+
+        layout.addLayout(wrapper)
+
+    def _render_mode_list(self, card_layout):
+        from qtpy.QtWidgets import QListWidget, QListWidgetItem, QAbstractItemView
+
+        card = CardWidget("")
+        card.content_layout.setContentsMargins(4, 4, 4, 4)
+
+        list_widget = QListWidget()
+        list_widget.setDragDropMode(QAbstractItemView.InternalMove)
+        list_widget.setSelectionMode(QAbstractItemView.SingleSelection)
+        list_widget.setFocusPolicy(Qt.NoFocus)
+        list_widget.setFrameShape(QFrame.NoFrame)
+        list_widget.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        list_widget.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        list_widget.setStyleSheet(
+            "QListWidget { background: transparent; } QListWidget::item { margin: 2px 0; }"
+        )
+
+        # Get current order from config
+        order_str = self.current_values.get(
+            "ModeOrder",
+            "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default",
+        )
+        order = order_str.split(",")
+
+        # Ensure all modes are present
+        all_internal_names = list(MODE_KEY_TO_INTERNAL_NAME.values())
+        for name in all_internal_names:
+            if name not in order:
+                order.append(name)
+
+        # Map internal name back to shortcut key
+        internal_to_key = {v: k for k, v in MODE_KEY_TO_INTERNAL_NAME.items()}
+
+        total_height = 0
+        for name in order:
+            key = internal_to_key.get(name)
+            if not key:
+                continue
+
+            item_meta = self.all_metadata.get(key)
+            if not item_meta:
+                continue
+
+            list_item = QListWidgetItem(list_widget)
+            container = QWidget()
+            row_layout = QHBoxLayout(container)
+            row_layout.setContentsMargins(4, 2, 4, 2)
+            row_layout.setSpacing(4)
+
+            # Drag handle icon with fallback
+            handle = QLabel()
+            icon = QIcon.fromTheme("list-drag-handle")
+            if icon.isNull():
+                icon = QIcon.fromTheme("view-restore")
+            if icon.isNull():
+                icon = QIcon.fromTheme("grabber")
+
+            if not icon.isNull():
+                handle.setPixmap(icon.pixmap(16, 16))
+            else:
+                handle.setText("☰")
+                handle.setStyleSheet(
+                    "font-size: 14px; color: palette(mid); font-weight: bold;"
+                )
+
+            handle.setFixedSize(24, 24)
+            handle.setAlignment(Qt.AlignCenter)
+            row_layout.addWidget(handle)
+
+            # Use the existing render logic but into our row
+            self._render_string(item_meta, row_layout)
+
+            hint = container.sizeHint()
+            # ONLY use the height from hint, use small width to let QListWidget expand it properly.
+            # Large width hints from QHBoxLayout+Stretch cause overflow.
+            list_item.setSizeHint(QSize(100, hint.height()))
+            total_height += hint.height() + 4  # 4 for margins/spacing
+
+            list_widget.addItem(list_item)
+            list_widget.setItemWidget(list_item, container)
+
+            # Store internal name in the item's data for reordering
+            list_item.setData(Qt.UserRole, name)
+
+        self.list_widgets.append(list_widget)
+        list_widget.model().rowsMoved.connect(
+            lambda: self._update_mode_order(list_widget)
+        )
+
+        card.content_layout.addWidget(list_widget)
+        card_layout.addWidget(card)
+
+    def _update_mode_order(self, list_widget):
+        new_order = []
+        for i in range(list_widget.count()):
+            item = list_widget.item(i)
+            new_order.append(item.data(Qt.UserRole))
+
+        self.update_config("ModeOrder", ",".join(new_order))
+
+    def _validate_mode_shortcuts(self):
+        """Check for duplicate shortcuts among enabled modes."""
+        self.validation_errors.clear()
+
+        # Reset warnings and styles
+        for key in MODE_SHORTCUT_KEYS:
+            if key in self.shortcut_warning_labels:
+                self.shortcut_warning_labels[key].hide()
+            if key in self.shortcut_labels:
+                self.shortcut_labels[key].setStyleSheet("")
+
+        # Only check enabled modes
+        enabled_shortcuts = {}
+        for shortcut_key, visibility_key in MODE_SHORTCUT_TO_VISIBILITY.items():
+            is_enabled = (
+                str(self.current_values.get(visibility_key, "True")).lower() == "true"
+            )
+            if is_enabled:
+                val = self.current_values.get(shortcut_key, "")
+                if val:
+                    if val in enabled_shortcuts:
+                        enabled_shortcuts[val].append(shortcut_key)
+                    else:
+                        enabled_shortcuts[val] = [shortcut_key]
+
+        # Flag duplicates
+        for shortcut, keys in enabled_shortcuts.items():
+            if len(keys) > 1:
+                error_msg = _(
+                    "Duplicate shortcut '{}' used for multiple enabled modes."
+                ).format(shortcut)
+                self.validation_errors.append(error_msg)
+                for key in keys:
+                    if key in self.shortcut_warning_labels:
+                        self.shortcut_warning_labels[key].setText(error_msg)
+                        self.shortcut_warning_labels[key].show()
+                    if key in self.shortcut_labels:
+                        self.shortcut_labels[key].setStyleSheet(
+                            "color: palette(highlight); font-weight: bold;"
+                        )
+
     def load_data(self):
         """Standardized reload method (alias for load_config)."""
         self.load_config()
@@ -293,8 +616,12 @@ class DynamicSettingsPage(QWidget):
 
     def save_data(self):
         """Commits all staged changes to DBus."""
+        self._validate_mode_shortcuts()
+        if self.validation_errors:
+            return False
+
         if not self.modified_values:
-            return
+            return True
 
         config_data = self.dbus.get_config()
         if config_data:
@@ -303,6 +630,7 @@ class DynamicSettingsPage(QWidget):
             self.dbus.set_config(latest_values)
             self.modified_values.clear()
             self.initial_values = self.current_values.copy()
+        return True
 
     def update_config(self, key: str, new_value):
         """Updates internal state and notifies parent window of change."""
@@ -312,3 +640,7 @@ class DynamicSettingsPage(QWidget):
         main_win = self.window()
         if hasattr(main_win, "on_changed"):
             main_win.on_changed()
+
+        # Real-time validation if it's a shortcut
+        if key in MODE_SHORTCUT_KEYS or key in MODE_SHORTCUT_TO_VISIBILITY.values():
+            self._validate_mode_shortcuts()

--- a/settings-gui/ui/pages/macro_editor.py
+++ b/settings-gui/ui/pages/macro_editor.py
@@ -62,12 +62,12 @@ class MacroEditorPage(BaseEditorPage):
         self.cb_enable.toggled.connect(self._on_item_changed)
         self.cb_capitalize.toggled.connect(self._on_item_changed)
         toggles_layout.addWidget(self.cb_enable)
-        
+
         cap_layout = QHBoxLayout()
         cap_layout.setSpacing(5)
         cap_layout.addWidget(self.cb_capitalize)
         add_help_icon(cap_layout, "CapitalizeMacro")
-        
+
         toggles_layout.addLayout(cap_layout)
         toggles_layout.addStretch()
 
@@ -91,25 +91,25 @@ class MacroEditorPage(BaseEditorPage):
         # Dynamic Macro Settings (Moved below the macro table)
         dynamic_card = CardWidget("")
         dynamic_layout = QVBoxLayout()
-        
+
         # Hint text
         hint_label = QLabel(_("Macros support dynamic placeholders: $TIME and $DATE."))
         hint_label.setWordWrap(True)
         hint_label.setStyleSheet("color: gray; font-size: 13px;")
         dynamic_layout.addWidget(hint_label)
-        
+
         # Format Inputs
         fmt_container = QWidget()
         fmt_hbox = QHBoxLayout(fmt_container)
         fmt_hbox.setContentsMargins(0, 5, 0, 0)
         fmt_hbox.setSpacing(20)
-        
+
         # Time Format
         time_layout = QHBoxLayout()
         self.input_time_format = QComboBox()
         self.input_time_format.setEditable(False)
         self.input_time_format.currentIndexChanged.connect(self._on_item_changed)
-        
+
         time_presets = [
             ("%H:%M", "15:04 (24h)"),
             ("%H:%M:%S", "15:04:05 (24h)"),
@@ -119,11 +119,13 @@ class MacroEditorPage(BaseEditorPage):
         ]
         for fmt, desc in time_presets:
             self.input_time_format.addItem(fmt, fmt)
-            self.input_time_format.setItemData(self.input_time_format.count() - 1, desc, Qt.ToolTipRole)
+            self.input_time_format.setItemData(
+                self.input_time_format.count() - 1, desc, Qt.ToolTipRole
+            )
 
         time_layout.addWidget(QLabel(_("Time Format:")))
         time_layout.addWidget(self.input_time_format, 1)
-        
+
         # Date Format
         date_layout = QHBoxLayout()
         self.input_date_format = QComboBox()
@@ -140,16 +142,18 @@ class MacroEditorPage(BaseEditorPage):
         ]
         for fmt, desc in date_presets:
             self.input_date_format.addItem(fmt, fmt)
-            self.input_date_format.setItemData(self.input_date_format.count() - 1, desc, Qt.ToolTipRole)
+            self.input_date_format.setItemData(
+                self.input_date_format.count() - 1, desc, Qt.ToolTipRole
+            )
 
         date_layout.addWidget(QLabel(_("Date Format:")))
         date_layout.addWidget(self.input_date_format, 1)
-        
+
         fmt_hbox.addLayout(time_layout)
         fmt_hbox.addLayout(date_layout)
-        
+
         dynamic_layout.addWidget(fmt_container)
-        
+
         dynamic_card.content_layout.addLayout(dynamic_layout)
         main_layout.addWidget(dynamic_card)
 
@@ -233,7 +237,9 @@ class MacroEditorPage(BaseEditorPage):
                     self.input_time_format.setCurrentIndex(index)
                 else:
                     # Fallback to default if not in list (since it's not editable anymore)
-                    self.input_time_format.setCurrentIndex(self.input_time_format.findData("%H:%M"))
+                    self.input_time_format.setCurrentIndex(
+                        self.input_time_format.findData("%H:%M")
+                    )
 
                 # Set date format
                 date_fmt = values.get("DateFormat", "%d/%m/%Y")
@@ -241,7 +247,9 @@ class MacroEditorPage(BaseEditorPage):
                 if index >= 0:
                     self.input_date_format.setCurrentIndex(index)
                 else:
-                    self.input_date_format.setCurrentIndex(self.input_date_format.findData("%d/%m/%Y"))
+                    self.input_date_format.setCurrentIndex(
+                        self.input_date_format.findData("%d/%m/%Y")
+                    )
 
             self.table.setRowCount(0)
             data = self.dbus.get_sub_config_list("lotus-macro", "Macro")
@@ -284,7 +292,10 @@ class MacroEditorPage(BaseEditorPage):
             val_item = self.table.item(row, 1)
             if key_item and key_item.text():
                 data.append(
-                    {"Key": key_item.text(), "Value": val_item.text() if val_item else ""}
+                    {
+                        "Key": key_item.text(),
+                        "Value": val_item.text() if val_item else "",
+                    }
                 )
         return {
             "data": data,
@@ -391,9 +402,11 @@ class MacroEditorPage(BaseEditorPage):
             val_item = self.table.item(row, 1)
             key = key_item.text().lower() if key_item else ""
             val = val_item.text().lower() if val_item else ""
-            
+
             # Show row if either key or value matches search text
-            self.table.setRowHidden(row, search_text not in key and search_text not in val)
+            self.table.setRowHidden(
+                row, search_text not in key and search_text not in val
+            )
 
     def on_add(self):
         key = self.input_key.text().strip()
@@ -411,11 +424,13 @@ class MacroEditorPage(BaseEditorPage):
         key = self.input_key.text().strip()
         val = self.input_val.text().strip()
         is_invalid = self._is_invalid_macro(key)
-        
+
         # Validation feedback for input field
         if is_invalid:
             self.input_key.setStyleSheet("color: red;")
-            self.input_key.setToolTip(_("Macro keys cannot contain spaces or special characters."))
+            self.input_key.setToolTip(
+                _("Macro keys cannot contain spaces or special characters.")
+            )
         else:
             self.input_key.setStyleSheet("")
             self.input_key.setToolTip("")

--- a/settings-gui/ui/pages/macro_editor.py
+++ b/settings-gui/ui/pages/macro_editor.py
@@ -57,7 +57,7 @@ class MacroEditorPage(BaseEditorPage):
         # Macro behavior toggles
         toggles_card = CardWidget("")
         toggles_layout = QHBoxLayout()
-        self.cb_enable = QCheckBox(_("Macro"))
+        self.cb_enable = QCheckBox(_("Enable Macro"))
         self.cb_capitalize = QCheckBox(_("Capitalize Macro"))
         self.cb_enable.toggled.connect(self._on_item_changed)
         self.cb_capitalize.toggled.connect(self._on_item_changed)

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -211,6 +211,8 @@ namespace fcitx {
         OptionWithAnnotation<std::string, StringListAnnotation> outputCharset{this, "OutputCharset", _("Output Charset"), "Unicode", {}, {}, StringListAnnotation()};
         KeyListOption                                           modeMenuKey{
             this, "ModeMenuKey", _("Mode Menu Hotkey"), {Key("grave")}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};
+        KeyListOption                                           cycleModeKey{
+            this, "CycleModeKey", _("Cycle Mode Hotkey"), {}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};
         SubConfigOption                                                                appRules{this, "AppRules", _("App Rules"), "fcitx://config/addon/lotus/app_rules"};
         OptionWithAnnotation<W2UMode, W2UModeI18NAnnotation>                           w2u{this, "W2U", _("Type w to Produce ư"), W2UMode::NonStart};
         OptionWithAnnotation<BracketTransformMode, BracketTransformModeI18NAnnotation> bracketTransform{this, "BracketTransform", _("Type [ -> ơ, ] -> ư, { -> Ơ, } -> Ư"),
@@ -231,12 +233,26 @@ namespace fcitx {
         Option<bool> enableDictionary{this, "EnableDictionary", _("Custom Dictionary"), false};
         Option<bool> enableCustomKeymap{this, "EnableCustomKeymap", _("Custom Keymap"), false};
 
-        Option<bool> showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true}; Option<bool> showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};
+        Option<bool> showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true};
+        Option<std::string> shortcutSmooth{this, "ShortcutSmooth", _("Shortcut for Uinput (Smooth)"), "1"};
+        Option<bool> showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};
+        Option<std::string> shortcutUinput{this, "ShortcutUinput", _("Shortcut for Uinput (Slow)"), "2"};
         Option<bool> showModeSuperSmooth{this, "ShowModeSuperSmooth", _("Show Uinput (Super Smooth)"), true};
+        Option<std::string> shortcutSuperSmooth{this, "ShortcutSuperSmooth", _("Shortcut for Uinput (Super Smooth)"), "a"};
         Option<bool> showModeMinecraft{this, "ShowModeMinecraft", _("Show Minecraft"), true};
+        Option<std::string> shortcutMinecraft{this, "ShortcutMinecraft", _("Shortcut for Minecraft"), "3"};
         Option<bool> showModeSurroundingText{this, "ShowModeSurroundingText", _("Show Surrounding Text"), true};
-        Option<bool> showModePreedit{this, "ShowModePreedit", _("Show Preedit"), true}; Option<bool> showModeEmoji{this, "ShowModeEmoji", _("Show Emoji Picker"), true};
-        Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true}; Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
+        Option<std::string> shortcutSurroundingText{this, "ShortcutSurroundingText", _("Shortcut for Surrounding Text"), "4"};
+        Option<bool> showModePreedit{this, "ShowModePreedit", _("Show Preedit"), true};
+        Option<std::string> shortcutPreedit{this, "ShortcutPreedit", _("Shortcut for Preedit"), "q"};
+        Option<bool> showModeEmoji{this, "ShowModeEmoji", _("Show Emoji Picker"), true};
+        Option<std::string> shortcutEmoji{this, "ShortcutEmoji", _("Shortcut for Emoji Picker"), "w"};
+        Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true};
+        Option<std::string> shortcutOff{this, "ShortcutOff", _("Shortcut for OFF"), "e"};
+        Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
+        Option<std::string> shortcutDefault{this, "ShortcutDefault", _("Shortcut for Default Typing"), "r"};
+
+        Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default"};
 
         OptionWithAnnotation<std::string, TimeFormatAnnotation>  timeFormat{this, "TimeFormat", _("Time Format ($TIME in macro)"), "%H:%M", {}, {}, TimeFormatAnnotation()};
         OptionWithAnnotation<std::string, DateFormatAnnotation>  dateFormat{this, "DateFormat", _("Date Format ($DATE in macro)"), "%d/%m/%Y", {}, {}, DateFormatAnnotation()};

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -211,45 +211,42 @@ namespace fcitx {
         OptionWithAnnotation<std::string, StringListAnnotation> outputCharset{this, "OutputCharset", _("Output Charset"), "Unicode", {}, {}, StringListAnnotation()};
         KeyListOption                                           modeMenuKey{
             this, "ModeMenuKey", _("Mode Menu Hotkey"), {Key("grave")}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};
-        KeyListOption                                           cycleModeKey{
-            this, "CycleModeKey", _("Cycle Mode Hotkey"), {}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};
+        KeyListOption cycleModeKey{this, "CycleModeKey", _("Cycle Mode Hotkey"), {}, KeyListConstrain({KeyConstrainFlag::AllowModifierLess, KeyConstrainFlag::AllowModifierOnly})};
         SubConfigOption                                                                appRules{this, "AppRules", _("App Rules"), "fcitx://config/addon/lotus/app_rules"};
         OptionWithAnnotation<W2UMode, W2UModeI18NAnnotation>                           w2u{this, "W2U", _("Type w to Produce ư"), W2UMode::NonStart};
         OptionWithAnnotation<BracketTransformMode, BracketTransformModeI18NAnnotation> bracketTransform{this, "BracketTransform", _("Type [ -> ơ, ] -> ư, { -> Ơ, } -> Ư"),
                                                                                                         BracketTransformMode::Disabled};
 
         Option<bool> spellCheck{this, "SpellCheck", _("Enable Spell Check"), true}; Option<bool> enableMacro{this, "EnableMacro", _("Enable Macro"), true};
-        Option<bool> capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true}; Option<bool> autoCapitalizeAfterPunctuation{
-            this, "AutoCapitalizeAfterPunctuation", _("Auto capitalize after sentence-ending punctuation (. ! ? Enter)"), false};
-        Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period"), false};
-        Option<bool> doubleHyphenToEmDash{this, "DoubleHyphenToEmDash", _("Double Hyphen to Em-Dash (--)"), false};
-        Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Invalid Words"), true};
-        Option<bool> modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
-        Option<bool> freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
-        Option<bool> ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Invalid Words Is On"), true};
-        Option<bool> fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
-        Option<bool> useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
+        Option<bool>                                                                             capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true};
+        Option<bool>        autoCapitalizeAfterPunctuation{this, "AutoCapitalizeAfterPunctuation", _("Auto capitalize after sentence-ending punctuation (. ! ? Enter)"), false};
+        Option<bool>        doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period"), false};
+        Option<bool>        doubleHyphenToEmDash{this, "DoubleHyphenToEmDash", _("Double Hyphen to Em-Dash (--)"), false};
+        Option<bool>        autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Invalid Words"), true};
+        Option<bool>        modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};
+        Option<bool>        freeMarking{this, "FreeMarking", _("Allow Type With More Freedom"), true};
+        Option<bool>        ddFreeStyle{this, "DdFreeStyle", _("Allow dd To Produce đ When Auto Restore Invalid Words Is On"), true};
+        Option<bool>        fixUinputWithAck{this, "FixUinputWithAck", _("Fix Uinput Mode With Ack"), false};
+        Option<bool>        useLotusIcons{this, "UseLotusIcons", _("Use Lotus Status Icons"), false};
 
-        Option<bool> enableDictionary{this, "EnableDictionary", _("Custom Dictionary"), false};
-        Option<bool> enableCustomKeymap{this, "EnableCustomKeymap", _("Custom Keymap"), false};
+        Option<bool>        enableDictionary{this, "EnableDictionary", _("Custom Dictionary"), false};
+        Option<bool>        enableCustomKeymap{this, "EnableCustomKeymap", _("Custom Keymap"), false};
 
-        Option<bool> showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true};
+        Option<bool>        showModeSmooth{this, "ShowModeSmooth", _("Show Uinput (Smooth)"), true};
         Option<std::string> shortcutSmooth{this, "ShortcutSmooth", _("Shortcut for Uinput (Smooth)"), "1"};
-        Option<bool> showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};
+        Option<bool>        showModeUinput{this, "ShowModeUinput", _("Show Uinput (Slow)"), true};
         Option<std::string> shortcutUinput{this, "ShortcutUinput", _("Shortcut for Uinput (Slow)"), "2"};
-        Option<bool> showModeSuperSmooth{this, "ShowModeSuperSmooth", _("Show Uinput (Super Smooth)"), true};
+        Option<bool>        showModeSuperSmooth{this, "ShowModeSuperSmooth", _("Show Uinput (Super Smooth)"), true};
         Option<std::string> shortcutSuperSmooth{this, "ShortcutSuperSmooth", _("Shortcut for Uinput (Super Smooth)"), "a"};
-        Option<bool> showModeMinecraft{this, "ShowModeMinecraft", _("Show Minecraft"), true};
+        Option<bool>        showModeMinecraft{this, "ShowModeMinecraft", _("Show Minecraft"), true};
         Option<std::string> shortcutMinecraft{this, "ShortcutMinecraft", _("Shortcut for Minecraft"), "3"};
-        Option<bool> showModeSurroundingText{this, "ShowModeSurroundingText", _("Show Surrounding Text"), true};
+        Option<bool>        showModeSurroundingText{this, "ShowModeSurroundingText", _("Show Surrounding Text"), true};
         Option<std::string> shortcutSurroundingText{this, "ShortcutSurroundingText", _("Shortcut for Surrounding Text"), "4"};
-        Option<bool> showModePreedit{this, "ShowModePreedit", _("Show Preedit"), true};
+        Option<bool>        showModePreedit{this, "ShowModePreedit", _("Show Preedit"), true};
         Option<std::string> shortcutPreedit{this, "ShortcutPreedit", _("Shortcut for Preedit"), "q"};
-        Option<bool> showModeEmoji{this, "ShowModeEmoji", _("Show Emoji Picker"), true};
-        Option<std::string> shortcutEmoji{this, "ShortcutEmoji", _("Shortcut for Emoji Picker"), "w"};
-        Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true};
-        Option<std::string> shortcutOff{this, "ShortcutOff", _("Shortcut for OFF"), "e"};
-        Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
+        Option<bool>        showModeEmoji{this, "ShowModeEmoji", _("Show Emoji Picker"), true};
+        Option<std::string> shortcutEmoji{this, "ShortcutEmoji", _("Shortcut for Emoji Picker"), "w"}; Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true};
+        Option<std::string> shortcutOff{this, "ShortcutOff", _("Shortcut for OFF"), "e"}; Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
         Option<std::string> shortcutDefault{this, "ShortcutDefault", _("Shortcut for Default Typing"), "r"};
 
         Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default"};

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -220,8 +220,8 @@ namespace fcitx {
 
         Option<bool> spellCheck{this, "SpellCheck", _("Enable Spell Check"), true}; Option<bool> enableMacro{this, "EnableMacro", _("Enable Macro"), true};
         Option<bool> capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"), true}; Option<bool> autoCapitalizeAfterPunctuation{
-            this, "AutoCapitalizeAfterPunctuation", _("Auto capitalize after sentence-ending punctuation (. ! ? Enter) (experimental)"), false};
-        Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period (experimental)"), false};
+            this, "AutoCapitalizeAfterPunctuation", _("Auto capitalize after sentence-ending punctuation (. ! ? Enter)"), false};
+        Option<bool> doubleSpaceToPeriod{this, "DoubleSpaceToPeriod", _("Double Space to Period"), false};
         Option<bool> doubleHyphenToEmDash{this, "DoubleHyphenToEmDash", _("Double Hyphen to Em-Dash (--)"), false};
         Option<bool> autoNonVnRestore{this, "AutoNonVnRestore", _("Auto Restore Invalid Words"), true};
         Option<bool> modernStyle{this, "ModernStyle", _("Use oà, uý (Instead Of òa, úy)"), true};

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -631,7 +631,7 @@ namespace fcitx {
                     }
                 }
                 if (visible) {
-                    LotusMode mode;
+                    std::optional<LotusMode> mode = std::nullopt;
                     if (name == "Smooth")
                         mode = LotusMode::Smooth;
                     else if (name == "Uinput")
@@ -661,7 +661,7 @@ namespace fcitx {
                         }
                     }
                     if (!duplicate) {
-                        enabledModes.push_back(mode);
+                        enabledModes.push_back(mode.value());
                     }
                 }
             }
@@ -1042,7 +1042,7 @@ namespace fcitx {
         candidateList->setLayoutHint(CandidateLayoutHint::Vertical);
         candidateList->setPageSize(1);
 
-        auto cleanup = [this](InputContext* ic) {
+        auto cleanup = [](InputContext* ic) {
             ic->inputPanel().reset();
             ic->updateUserInterface(UserInterfaceComponent::InputPanel);
         };
@@ -1061,7 +1061,7 @@ namespace fcitx {
             default: modeLabel = _("Unknown Mode"); break;
         }
 
-        auto setCurrentMode = [this, cleanup](LotusMode m) { return [this, m, cleanup](InputContext* ic) { cleanup(ic); }; };
+        auto setCurrentMode = [cleanup](LotusMode) { return [cleanup](InputContext* ic) { cleanup(ic); }; };
 
         candidateList->append(std::make_unique<AppModeCandidateWord>(Text("✓ " + modeLabel), setCurrentMode(mode)));
 

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -608,16 +608,7 @@ namespace fcitx {
         if (!keyEvent.isRelease() && !config_.cycleModeKey->empty() && keyEvent.key().checkKeyList(*config_.cycleModeKey)) {
             LOTUS_INFO("Cycle mode key pressed");
             std::string appName  = getProgramName(ic);
-            LotusMode   realMode = LotusMode::Preedit;
-#if __cplusplus >= 202002L
-            if (appRules_.contains(appName)) {
-#else
-            if (appRules_.find(appName) != appRules_.end()) {
-#endif
-                realMode = appRules_[appName];
-            } else {
-                realMode = config().mode.value();
-            }
+            LotusMode   realMode = getAppRule(appName);
 
             auto                                      order      = stringutils::split(*config_.modeOrder, ",");
             std::vector<std::pair<std::string, bool>> visibility = {{"Smooth", *config_.showModeSmooth},
@@ -640,24 +631,38 @@ namespace fcitx {
                     }
                 }
                 if (visible) {
+                    LotusMode mode;
                     if (name == "Smooth")
-                        enabledModes.push_back(LotusMode::Smooth);
+                        mode = LotusMode::Smooth;
                     else if (name == "Uinput")
-                        enabledModes.push_back(LotusMode::Uinput);
+                        mode = LotusMode::Uinput;
                     else if (name == "Minecraft")
-                        enabledModes.push_back(LotusMode::Minecraft);
+                        mode = LotusMode::Minecraft;
                     else if (name == "SurroundingText")
-                        enabledModes.push_back(LotusMode::SurroundingText);
+                        mode = LotusMode::SurroundingText;
                     else if (name == "Preedit")
-                        enabledModes.push_back(LotusMode::Preedit);
+                        mode = LotusMode::Preedit;
                     else if (name == "Emoji")
-                        enabledModes.push_back(LotusMode::Emoji);
+                        mode = LotusMode::Emoji;
                     else if (name == "Off")
-                        enabledModes.push_back(LotusMode::Off);
+                        mode = LotusMode::Off;
                     else if (name == "SuperSmooth")
-                        enabledModes.push_back(LotusMode::SuperSmooth);
+                        mode = LotusMode::SuperSmooth;
                     else if (name == "Default")
-                        enabledModes.push_back(config().mode.value());
+                        mode = config().mode.value();
+                    else
+                        continue;
+
+                    bool duplicate = false;
+                    for (auto m : enabledModes) {
+                        if (m == mode) {
+                            duplicate = true;
+                            break;
+                        }
+                    }
+                    if (!duplicate) {
+                        enabledModes.push_back(mode);
+                    }
                 }
             }
 

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -607,8 +607,8 @@ namespace fcitx {
 
         if (!keyEvent.isRelease() && !config_.cycleModeKey->empty() && keyEvent.key().checkKeyList(*config_.cycleModeKey)) {
             LOTUS_INFO("Cycle mode key pressed");
-            std::string appName  = getProgramName(ic);
-            LotusMode   realMode = getAppRule(appName);
+            std::string                               appName  = getProgramName(ic);
+            LotusMode                                 realMode = getAppRule(appName);
 
             auto                                      order      = stringutils::split(*config_.modeOrder, ",");
             std::vector<std::pair<std::string, bool>> visibility = {{"Smooth", *config_.showModeSmooth},

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -1074,15 +1074,13 @@ namespace fcitx {
         auto  now_time     = ::fcitx::now(CLOCK_MONOTONIC);
         auto  timeout_time = now_time + CYCLE_MODE_NOTIFICATION_TIMEOUT_USEC;
 
-        cycleModeNotificationTimer_ = eventLoop.addTimeEvent(
-            CLOCK_MONOTONIC, timeout_time, 0,
-            [icRef = ic->watch()](EventSourceTime*, uint64_t) {
-                if (auto* ic = icRef.get(); ic && ic->hasFocus()) {
-                    ic->inputPanel().reset();
-                    ic->updateUserInterface(UserInterfaceComponent::InputPanel);
-                }
-                return false;
-            });
+        cycleModeNotificationTimer_ = eventLoop.addTimeEvent(CLOCK_MONOTONIC, timeout_time, 0, [icRef = ic->watch()](EventSourceTime*, uint64_t) {
+            if (auto* ic = icRef.get(); ic && ic->hasFocus()) {
+                ic->inputPanel().reset();
+                ic->updateUserInterface(UserInterfaceComponent::InputPanel);
+            }
+            return false;
+        });
     }
 
     void LotusEngine::setMode(LotusMode mode, InputContext* ic) {

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -21,12 +21,15 @@
 #include <fcitx-config/iniparser.h>
 #include <fcitx/menu.h>
 #include <fcitx/userinterfacemanager.h>
+#include <fcitx-utils/event.h>
 #include <fcitx-utils/utf8.h>
+#include <fcitx-utils/eventdispatcher.h>
 
 #include <atomic>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <unordered_set>
 
 #include <fcntl.h>
 #include <sstream>
@@ -67,16 +70,14 @@ namespace fcitx {
     // Returns the KeySym that triggers the "Type hotkey char" action in the mode
     // menu.  If the hotkey itself conflicts with a reserved menu key, falls back
     // to FcitxKey_f.
-    static bool isAppModeMenuReservedKey(KeySym sym) {
+    static bool isAppModeMenuReservedKey(KeySym sym, const lotusConfig& config) {
+        if (sym == Key(*config.shortcutSmooth).sym() || sym == Key(*config.shortcutUinput).sym() || sym == Key(*config.shortcutMinecraft).sym() ||
+            sym == Key(*config.shortcutSurroundingText).sym() || sym == Key(*config.shortcutPreedit).sym() || sym == Key(*config.shortcutEmoji).sym() ||
+            sym == Key(*config.shortcutOff).sym() || sym == Key(*config.shortcutSuperSmooth).sym() || sym == Key(*config.shortcutDefault).sym()) {
+            return true;
+        }
+
         switch (sym) {
-            case FcitxKey_1:
-            case FcitxKey_2:
-            case FcitxKey_3:
-            case FcitxKey_4:
-            case FcitxKey_q:
-            case FcitxKey_w:
-            case FcitxKey_e:
-            case FcitxKey_r:
             case FcitxKey_Escape:
             case FcitxKey_Tab:
             case FcitxKey_ISO_Left_Tab:
@@ -88,8 +89,8 @@ namespace fcitx {
         }
     }
 
-    static KeySym typeKeyForModeMenuHotkey(KeySym hotkeySym) {
-        return isAppModeMenuReservedKey(hotkeySym) ? FcitxKey_f : hotkeySym;
+    static KeySym typeKeyForModeMenuHotkey(KeySym hotkeySym, const lotusConfig& config) {
+        return isAppModeMenuReservedKey(hotkeySym, config) ? FcitxKey_f : hotkeySym;
     }
 
     bool LotusEngine::isDarkMode() {
@@ -549,7 +550,7 @@ namespace fcitx {
                         if (kl.size() == 1 && !kl[0].hasModifier()) {
                             std::string charStr = Key::keySymToUTF8(kl[0].sym());
                             if (!charStr.empty()) {
-                                if (keySym == typeKeyForModeMenuHotkey(kl[0].sym())) {
+                                if (keySym == typeKeyForModeMenuHotkey(kl[0].sym(), config_)) {
                                     isSelectingAppMode_ = false;
                                     ic->inputPanel().reset();
                                     ic->updateUserInterface(UserInterfaceComponent::InputPanel);
@@ -569,7 +570,7 @@ namespace fcitx {
             if (selectedMode != std::nullopt) {
                 LOTUS_INFO("Selected mode: " + LotusModeI18NAnnotation::toString(selectedMode.value()));
                 if (selectedMode != LotusMode::Emoji) {
-                    if (keySym == FcitxKey_r) { // Default Typing key (R)
+                    if (keySym == Key(*config_.shortcutDefault).sym()) { // Default Typing key
                         std::lock_guard<std::mutex> lock(appRulesMutex_);
                         appRules_.erase(currentConfigureApp_);
                         // Remove from the configuration object too
@@ -601,6 +602,81 @@ namespace fcitx {
                     }
                 }
             }
+            return;
+        }
+
+        if (!keyEvent.isRelease() && !config_.cycleModeKey->empty() && keyEvent.key().checkKeyList(*config_.cycleModeKey)) {
+            LOTUS_INFO("Cycle mode key pressed");
+            std::string appName  = getProgramName(ic);
+            LotusMode   realMode = LotusMode::Preedit;
+#if __cplusplus >= 202002L
+            if (appRules_.contains(appName)) {
+#else
+            if (appRules_.find(appName) != appRules_.end()) {
+#endif
+                realMode = appRules_[appName];
+            } else {
+                realMode = config().mode.value();
+            }
+
+            auto                                      order      = stringutils::split(*config_.modeOrder, ",");
+            std::vector<std::pair<std::string, bool>> visibility = {{"Smooth", *config_.showModeSmooth},
+                                                                    {"Uinput", *config_.showModeUinput},
+                                                                    {"Minecraft", *config_.showModeMinecraft},
+                                                                    {"SurroundingText", *config_.showModeSurroundingText},
+                                                                    {"Preedit", *config_.showModePreedit},
+                                                                    {"Emoji", *config_.showModeEmoji},
+                                                                    {"Off", *config_.showModeOff},
+                                                                    {"SuperSmooth", *config_.showModeSuperSmooth},
+                                                                    {"Default", *config_.showModeDefault}};
+
+            std::vector<LotusMode>                    enabledModes;
+            for (const auto& name : order) {
+                bool visible = false;
+                for (const auto& v : visibility) {
+                    if (v.first == name) {
+                        visible = v.second;
+                        break;
+                    }
+                }
+                if (visible) {
+                    if (name == "Smooth")
+                        enabledModes.push_back(LotusMode::Smooth);
+                    else if (name == "Uinput")
+                        enabledModes.push_back(LotusMode::Uinput);
+                    else if (name == "Minecraft")
+                        enabledModes.push_back(LotusMode::Minecraft);
+                    else if (name == "SurroundingText")
+                        enabledModes.push_back(LotusMode::SurroundingText);
+                    else if (name == "Preedit")
+                        enabledModes.push_back(LotusMode::Preedit);
+                    else if (name == "Emoji")
+                        enabledModes.push_back(LotusMode::Emoji);
+                    else if (name == "Off")
+                        enabledModes.push_back(LotusMode::Off);
+                    else if (name == "SuperSmooth")
+                        enabledModes.push_back(LotusMode::SuperSmooth);
+                    else if (name == "Default")
+                        enabledModes.push_back(config().mode.value());
+                }
+            }
+
+            if (!enabledModes.empty()) {
+                size_t currentIdx = 0;
+                for (size_t i = 0; i < enabledModes.size(); ++i) {
+                    if (enabledModes[i] == realMode) {
+                        currentIdx = i;
+                        break;
+                    }
+                }
+
+                LotusMode nextMode = enabledModes[(currentIdx + 1) % enabledModes.size()];
+                setMode(nextMode, ic);
+                setAppRule(appName, nextMode);
+                showCycleModeNotification(nextMode, ic);
+            }
+
+            keyEvent.filterAndAccept();
             return;
         }
 
@@ -857,30 +933,58 @@ namespace fcitx {
             bool        visible;
         };
 
-        std::vector<ModeInfo> allModes = {
-            {LotusMode::Smooth, _("Uinput (Smooth)"), FcitxKey_1, *config_.showModeSmooth},
-            {LotusMode::Uinput, _("Uinput (Slow)"), FcitxKey_2, *config_.showModeUinput},
-            {LotusMode::Minecraft, _("Minecraft"), FcitxKey_3, *config_.showModeMinecraft},
-            {LotusMode::SurroundingText, _("Surrounding Text"), FcitxKey_4, *config_.showModeSurroundingText},
-            {LotusMode::Preedit, _("Preedit"), FcitxKey_q, *config_.showModePreedit},
-            {LotusMode::Emoji, _("Emoji Picker"), FcitxKey_w, *config_.showModeEmoji},
-            {LotusMode::Off, _("OFF"), FcitxKey_e, *config_.showModeOff},
-            {LotusMode::SuperSmooth, _("Uinput (Super Smooth)"), FcitxKey_a, *config_.showModeSuperSmooth},
-        };
+        auto                                      getShortcut = [](const std::string& shortcut) { return Key(shortcut).sym(); };
 
-        const LotusMode defaultMode = config_.mode.value();
-        allModes.push_back({defaultMode, _("Default Typing"), FcitxKey_r, *config_.showModeDefault}); // Add reset option
+        std::unordered_map<std::string, ModeInfo> modeMap = {
+            {"Smooth", {LotusMode::Smooth, _("Uinput (Smooth)"), getShortcut(*config_.shortcutSmooth), *config_.showModeSmooth}},
+            {"Uinput", {LotusMode::Uinput, _("Uinput (Slow)"), getShortcut(*config_.shortcutUinput), *config_.showModeUinput}},
+            {"Minecraft", {LotusMode::Minecraft, _("Minecraft"), getShortcut(*config_.shortcutMinecraft), *config_.showModeMinecraft}},
+            {"SurroundingText", {LotusMode::SurroundingText, _("Surrounding Text"), getShortcut(*config_.shortcutSurroundingText), *config_.showModeSurroundingText}},
+            {"Preedit", {LotusMode::Preedit, _("Preedit"), getShortcut(*config_.shortcutPreedit), *config_.showModePreedit}},
+            {"Emoji", {LotusMode::Emoji, _("Emoji Picker"), getShortcut(*config_.shortcutEmoji), *config_.showModeEmoji}},
+            {"Off", {LotusMode::Off, _("OFF"), getShortcut(*config_.shortcutOff), *config_.showModeOff}},
+            {"SuperSmooth", {LotusMode::SuperSmooth, _("Uinput (Super Smooth)"), getShortcut(*config_.shortcutSuperSmooth), *config_.showModeSuperSmooth}},
+            {"Default", {config_.mode.value(), _("Default Typing"), getShortcut(*config_.shortcutDefault), *config_.showModeDefault}}};
 
-        int activeSelectionIdx  = -1;
-        int currentCandidateIdx = 0;
+        std::vector<ModeInfo> allModes;
+        auto                  order = stringutils::split(*config_.modeOrder, ",");
+        for (const auto& name : order) {
+            auto it = modeMap.find(name);
+            if (it != modeMap.end()) {
+                allModes.push_back(it->second);
+            }
+        }
+
+        // Fallback for missing modes
+        for (const auto& [name, info] : modeMap) {
+            bool found = false;
+            for (const auto& orderedName : order) {
+                if (orderedName == name) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                allModes.push_back(info);
+            }
+        }
+
+        int                        activeSelectionIdx  = -1;
+        int                        currentCandidateIdx = 0;
+        std::unordered_set<KeySym> usedModeKeys;
 
         modeMenuMapping_.clear();
+        const LotusMode defaultMode = config_.mode.value();
 
         for (const auto& info : allModes) {
             if (info.visible) {
-                modeMenuMapping_[info.key] = info.mode;
+                const bool hasShortcut = info.key != FcitxKey_None && info.key != FcitxKey_VoidSymbol;
+                if (hasShortcut && usedModeKeys.insert(info.key).second) {
+                    modeMenuMapping_[info.key] = info.mode;
+                }
 
-                std::string keyLabel = "[" + Key::keySymToUTF8(info.key) + "] ";
+                const std::string keyUtf8  = Key::keySymToUTF8(info.key);
+                std::string       keyLabel = keyUtf8.empty() ? "" : "[" + keyUtf8 + "] ";
                 candidateList->append(std::make_unique<AppModeCandidateWord>(getLabel(info.mode, keyLabel + info.label), applyMode(info.mode)));
 
                 if (info.mode == realMode) {
@@ -905,7 +1009,7 @@ namespace fcitx {
             if (kl.size() == 1 && !kl[0].hasModifier()) {
                 std::string charStr = Key::keySymToUTF8(kl[0].sym());
                 if (!charStr.empty()) {
-                    KeySym      typeKeySym   = typeKeyForModeMenuHotkey(kl[0].sym());
+                    KeySym      typeKeySym   = typeKeyForModeMenuHotkey(kl[0].sym(), config_);
                     std::string typeKeyLabel = Key::keySymToUTF8(typeKeySym);
                     std::string label        = "[" + typeKeyLabel + "] " + _("Type") + " " + charStr;
                     candidateList->append(std::make_unique<AppModeCandidateWord>(Text(label), [cleanup, charStr](InputContext* ic) {
@@ -926,6 +1030,59 @@ namespace fcitx {
         ic->inputPanel().setCandidateList(std::move(candidateList));
         ic->inputPanel().setAuxDown(Text(_("App: ") + currentConfigureApp_));
         ic->updateUserInterface(UserInterfaceComponent::InputPanel);
+    }
+
+    void LotusEngine::showCycleModeNotification(LotusMode mode, InputContext* ic) {
+        auto candidateList = std::make_unique<CommonCandidateList>();
+        candidateList->setLayoutHint(CandidateLayoutHint::Vertical);
+        candidateList->setPageSize(1);
+
+        auto cleanup = [this](InputContext* ic) {
+            ic->inputPanel().reset();
+            ic->updateUserInterface(UserInterfaceComponent::InputPanel);
+        };
+
+        // Map mode to label
+        std::string modeLabel;
+        switch (mode) {
+            case LotusMode::Smooth: modeLabel = _("Uinput (Smooth)"); break;
+            case LotusMode::Uinput: modeLabel = _("Uinput (Slow)"); break;
+            case LotusMode::Minecraft: modeLabel = _("Minecraft"); break;
+            case LotusMode::SurroundingText: modeLabel = _("Surrounding Text"); break;
+            case LotusMode::Preedit: modeLabel = _("Preedit"); break;
+            case LotusMode::Emoji: modeLabel = _("Emoji Picker"); break;
+            case LotusMode::Off: modeLabel = _("OFF"); break;
+            case LotusMode::SuperSmooth: modeLabel = _("Uinput (Super Smooth)"); break;
+            default: modeLabel = _("Unknown Mode"); break;
+        }
+
+        auto setCurrentMode = [this, cleanup](LotusMode m) { return [this, m, cleanup](InputContext* ic) { cleanup(ic); }; };
+
+        candidateList->append(std::make_unique<AppModeCandidateWord>(Text("✓ " + modeLabel), setCurrentMode(mode)));
+
+        candidateList->setGlobalCursorIndex(0);
+
+        ic->inputPanel().reset();
+        ic->inputPanel().setCandidateList(std::move(candidateList));
+        ic->updateUserInterface(UserInterfaceComponent::InputPanel);
+
+        // Cancel previous timer if any
+        cycleModeNotificationTimer_.reset();
+
+        // Schedule auto-close using EventLoop::addTimeEvent
+        auto& eventLoop    = instance_->eventLoop();
+        auto  now_time     = ::fcitx::now(CLOCK_MONOTONIC);
+        auto  timeout_time = now_time + CYCLE_MODE_NOTIFICATION_TIMEOUT_USEC;
+
+        cycleModeNotificationTimer_ = eventLoop.addTimeEvent(
+            CLOCK_MONOTONIC, timeout_time, 0,
+            [icRef = ic->watch()](EventSourceTime*, uint64_t) {
+                if (auto* ic = icRef.get(); ic && ic->hasFocus()) {
+                    ic->inputPanel().reset();
+                    ic->updateUserInterface(UserInterfaceComponent::InputPanel);
+                }
+                return false;
+            });
     }
 
     void LotusEngine::setMode(LotusMode mode, InputContext* ic) {

--- a/src/lotus-engine.h
+++ b/src/lotus-engine.h
@@ -19,12 +19,14 @@
 #include "emoji.h"
 #include "lotus.h"
 #include <mutex>
+#include <memory>
 #include <fcitx-config/iniparser.h>
 #include <fcitx/action.h>
 #include <fcitx/addonfactory.h>
 #include <fcitx/addonmanager.h>
 #include <fcitx/inputmethodengine.h>
 #include <fcitx/instance.h>
+#include <fcitx-utils/eventloopinterface.h>
 
 namespace fcitx {
 
@@ -218,6 +220,8 @@ namespace fcitx {
         std::string                                appRulesPath_;
         bool                                       isSelectingAppMode_ = false;
         std::string                                currentConfigureApp_;
+        std::unique_ptr<EventSourceTime>           cycleModeNotificationTimer_;
+        static constexpr uint64_t                  CYCLE_MODE_NOTIFICATION_TIMEOUT_USEC = 800000; // 800ms in microseconds
         FCITX_ADDON_DEPENDENCY_LOADER(emoji, instance_->addonManager());
         std::unique_ptr<EmojiLoader>          emojiLoader_;
         bool                                  isGnome_ = false;
@@ -304,6 +308,13 @@ namespace fcitx {
          * @param ic Current input context.
          */
         void showAppModeMenu(InputContext* ic);
+
+        /**
+         * @brief Shows a brief notification of the cycled mode.
+         * @param mode The mode that was cycled to.
+         * @param ic Current input context.
+         */
+        void showCycleModeNotification(LotusMode mode, InputContext* ic);
 
         /**
          * @brief Closes the application mode selection menu.

--- a/src/lotus-engine.h
+++ b/src/lotus-engine.h
@@ -26,7 +26,7 @@
 #include <fcitx/addonmanager.h>
 #include <fcitx/inputmethodengine.h>
 #include <fcitx/instance.h>
-#include <fcitx-utils/eventloopinterface.h>
+#include <fcitx-utils/event.h>
 
 namespace fcitx {
 


### PR DESCRIPTION
### Description
This pull request introduces support for configurable cycle mode shortcuts and various UI refinements. Users can now define shortcuts to cycle through available input modes sequentially and reorder them within the settings interface.

### Changes
- **Core Engine**: Implemented cycleMode logic in LotusEngine and added support for custom single-key shortcuts for specific modes.
- **Settings GUI**: Added a new Shortcuts configuration page with drag-and-drop reordering, hotkey capture, and conflict validation.
- **UI Refinements**: Updated labels for clarity (e.g., Macro to Enable Macro) and removed (experimental) markers from stabilized features like Auto Capitalization and Double Space to Period.
- **Localization**: Updated translation templates and provided comprehensive Vietnamese translations for all new and modified strings.

### How Tested
- Verified build stability via local compilation.
- Confirmed UI functionality for mode reordering and shortcut assignment.
- Manually tested input mode cycling behavior in a live environment.