### PR TITLE
fix: prevent modifier-only keys from deleting selection in Surrounding Text mode

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -715,9 +715,7 @@ namespace fcitx {
         }
 
         const std::string& text   = surrounding.text();
-        unsigned int       cursor = surrounding.anchor() != surrounding.cursor()
-                                        ? std::min(surrounding.anchor(), surrounding.cursor())
-                                        : surrounding.cursor();
+        unsigned int       cursor = std::min(surrounding.anchor(), surrounding.cursor());
 
         size_t             textLen = utf8::lengthValidated(text);
 
@@ -872,9 +870,7 @@ namespace fcitx {
     }
 
     void LotusState::keyEvent(KeyEvent& keyEvent) {
-        if (!lotusEngine_ || keyEvent.isRelease() ||
-            keyEvent.rawKey().check(FcitxKey_Shift_L) || keyEvent.rawKey().check(FcitxKey_Shift_R) ||
-            keyEvent.rawKey().isModifier())
+        if (!lotusEngine_ || keyEvent.isRelease() || keyEvent.rawKey().isModifier())
             return;
         if (uinput_client_fd_ < 0) {
             LOTUS_WARN("Cannot connect to uinput server, reconnecting....");

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -714,12 +714,10 @@ namespace fcitx {
             return;
         }
 
-        if (surrounding.anchor() != surrounding.cursor()) {
-            ic->deleteSurroundingText(0, 0);
-        }
-
         const std::string& text   = surrounding.text();
-        unsigned int       cursor = surrounding.cursor();
+        unsigned int       cursor = surrounding.anchor() != surrounding.cursor()
+                                        ? std::min(surrounding.anchor(), surrounding.cursor())
+                                        : surrounding.cursor();
 
         size_t             textLen = utf8::lengthValidated(text);
 
@@ -874,7 +872,9 @@ namespace fcitx {
     }
 
     void LotusState::keyEvent(KeyEvent& keyEvent) {
-        if (!lotusEngine_ || keyEvent.isRelease() || keyEvent.rawKey().check(FcitxKey_Shift_L) || keyEvent.rawKey().check(FcitxKey_Shift_R))
+        if (!lotusEngine_ || keyEvent.isRelease() ||
+            keyEvent.rawKey().check(FcitxKey_Shift_L) || keyEvent.rawKey().check(FcitxKey_Shift_R) ||
+            keyEvent.rawKey().isModifier())
             return;
         if (uinput_client_fd_ < 0) {
             LOTUS_WARN("Cannot connect to uinput server, reconnecting....");


### PR DESCRIPTION
## Summary

Fixes #323

In Surrounding Text mode, pressing a modifier key alone (e.g. holding `Ctrl` before pressing another key) while text is selected caused the selection to be **immediately deleted** in Chrome URL bar, VSCode dialogs, and other Electron/GTK native inputs.

## Root Cause

Two issues combined:

**1.** `keyEvent()` early return only guarded `Shift_L/Shift_R`, allowing `Control_L/R`, `Alt_L/R`, `Super_L/R` to fall through into `handleSurroundingText()`.

**2.** Inside `handleSurroundingText()`, `deleteSurroundingText(0, 0)` was called whenever `anchor != cursor` (text selected). Chrome and Electron interpret this as a command to delete the current selection, even though `(0, 0)` nominally means "delete 0 characters".

## Changes

- **`keyEvent()`**: extend early return to use `rawKey().isModifier()` instead of checking only `Shift_L/Shift_R`
- **`handleSurroundingText()`**: remove `deleteSurroundingText(0, 0)` call on selection; use `min(anchor, cursor)` as the effective cursor position for surrounding text lookup

## Testing

Tested on KDE Wayland (EndeavourOS) with fcitx5 5.1.19:
- ✅ Chrome URL bar: selecting text + holding `Ctrl` no longer deletes selection
- ✅ VSCode file rename dialog: same fix
- ✅ Vietnamese input in Surrounding Text mode continues to work correctly
- ✅ Monaco editor (VSCode) unaffected