### PR TITLE
fix: Chrome input handling in SurroundingText mode (Wayland)

### DIFF
--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -418,13 +418,8 @@ namespace fcitx {
 
         state->waitAck_ = false;
 
-#if __cplusplus >= 202002L
         std::string appNameLower = appName;
-        std::ranges::transform(appNameLower, appNameLower.begin(), ::tolower);
-#else
-        std::string appNameLower = appName;
-        std::transform(appNameLower.begin(), appNameLower.end(), appNameLower.begin(), ::tolower);
-#endif
+        std::transform(appNameLower.begin(), appNameLower.end(), appNameLower.begin(), [](unsigned char c) { return std::tolower(c); });
 
         if (is_dbus && (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth)) {
             for (const auto& ackApp : ack_apps) {
@@ -455,6 +450,10 @@ namespace fcitx {
             LOTUS_INFO("Skip clearAllBuffers");
         } else if (surrvalid && !state->oldPreBuffer_.empty() && (now_ms() - state->lastDeactivateTime_) < 100) {
             state->clearAllBuffers();
+        }
+        // After focus-in, forward the first key raw so Chrome updates surrounding text before engine rebuild.
+        if (event.type() == EventType::InputContextFocusIn && targetMode == LotusMode::SurroundingText) {
+            state->skipSurrTextRebuild_ = true;
         }
         is_deleting_.store(false);
         needEngineReset.store(false);
@@ -634,7 +633,7 @@ namespace fcitx {
         state->keyEvent(keyEvent);
         const auto&  s       = ic->surroundingText();
         const auto&  text    = s.text();
-        size_t       textLen = fcitx_utf8_strlen(text.c_str());
+        size_t       textLen = text.size(); // byte length, matches cursor which is a byte offset
         unsigned int cursor  = s.cursor();
         if (textLen == static_cast<size_t>(cursor))
             realtextLen.store(static_cast<unsigned int>(textLen), std::memory_order_release);

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -413,25 +413,41 @@ namespace fcitx {
         // it not support surrounding text so can't know when it show suggestions
         //
         // TODO: Properly fixes instead ugly WA
-        state->wa_chromium_flag = false;
+        state->wa_chromium_flag             = false;
+        state->wa_chrome_forwardkey_delete_ = false;
 
         state->waitAck_ = false;
-        if (*config_.fixUinputWithAck) {
-            if (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth) {
+
 #if __cplusplus >= 202002L
-                std::ranges::transform(appName, appName.begin(), ::tolower);
+        std::string appNameLower = appName;
+        std::ranges::transform(appNameLower, appNameLower.begin(), ::tolower);
 #else
-                std::transform(appName.begin(), appName.end(), appName.begin(), ::tolower);
+        std::string appNameLower = appName;
+        std::transform(appNameLower.begin(), appNameLower.end(), appNameLower.begin(), ::tolower);
 #endif
-                for (const auto& ackApp : ack_apps) {
-                    if (appName.find(ackApp) != std::string::npos) {
-                        if (is_dbus) {
-                            state->waitAck_ = true;
-                            LOTUS_INFO(ackApp + " detected, waiting for ack");
-                        }
-                        state->wa_chromium_flag = true;
-                        break;
+
+        if (is_dbus && (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth)) {
+            for (const auto& ackApp : ack_apps) {
+                if (appNameLower.find(ackApp) != std::string::npos) {
+                    state->wa_chromium_flag             = true;
+                    state->wa_chrome_forwardkey_delete_ = true;
+                    if (*config_.fixUinputWithAck) {
+                        state->waitAck_ = true;
+                        LOTUS_INFO(ackApp + " detected, waiting for ack");
+                    } else {
+                        LOTUS_INFO(ackApp + " detected, using commit+forwardKey workaround");
                     }
+                    break;
+                }
+            }
+        }
+        // Chrome ignores deleteSurroundingText when URL bar autocomplete is active; use forwardKey.
+        if (targetMode == LotusMode::SurroundingText) {
+            for (const auto& ackApp : ack_apps) {
+                if (appNameLower.find(ackApp) != std::string::npos) {
+                    state->wa_chrome_forwardkey_delete_ = true;
+                    LOTUS_INFO(ackApp + " detected in SurroundingText mode, using forwardKey for delete");
+                    break;
                 }
             }
         }
@@ -627,7 +643,8 @@ namespace fcitx {
     void LotusEngine::reset(const InputMethodEntry& /*entry*/, InputContextEvent& event) {
         LOTUS_INFO("Reset engine");
         auto* state = event.inputContext()->propertyFor(&factory_);
-        if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut) {
+        // InputContextReset (e.g., Chrome Ctrl+Tab) must bypass the history guard or the engine stays stale.
+        if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut && event.type() != EventType::InputContextReset) {
             return;
         }
 

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -144,13 +144,13 @@ namespace fcitx {
             return false;
         }
 
-        const unsigned int cursor  = s.cursor();
-        const unsigned int anchor  = s.anchor();
-        const auto&        text    = s.text();
-        const size_t       textLen = utf8::length(text);
+        const unsigned int cursor = s.cursor();
+        const unsigned int anchor = s.anchor();
+        const auto&        text   = s.text();
+        // Use byte lengths to match cursor/anchor which are byte offsets in text-input-v3.
+        const size_t textLen = text.size();
+        const size_t buffLen = oldPreBuffer_.size();
 
-        // Fix that surrounding text is delay update
-        const size_t buffLen    = utf8::length(oldPreBuffer_);
         const size_t pb         = text.find(oldPreBuffer_);
         size_t       rangeStart = static_cast<size_t>(cursor) >= buffLen ? static_cast<size_t>(cursor) - buffLen : 0;
         const bool   sameprefix = pb != std::string::npos && pb >= rangeStart && pb <= static_cast<size_t>(cursor);
@@ -162,7 +162,8 @@ namespace fcitx {
 
             // Only consider it browser autofill if the selection starts at the cursor
             // and extends to the end of the line (common address bar behavior).
-            if (selectionStart >= cursor || (selectionStart < cursor && selectionEnd > cursor)) {
+            // selectionStart == cursor means anchor > cursor (selection extends forward).
+            if (selectionStart == cursor) {
                 if (!sameprefix)
                     return false;
                 // If the selection contains a newline, it's likely a multiline editor (AI ghost text),
@@ -173,7 +174,7 @@ namespace fcitx {
         }
 
         if (textLen == static_cast<size_t>(cursor)) {
-            realtextLen.store(textLen, std::memory_order_release);
+            realtextLen.store(static_cast<unsigned int>(textLen), std::memory_order_release);
             return false;
         }
 
@@ -556,6 +557,23 @@ namespace fcitx {
         return false;
     }
 
+    void LotusState::chromeForwardDelete(KeyEvent& keyEvent, const std::string& deletedPart, const std::string& addedPart) {
+        keyEvent.filterAndAccept();
+        size_t charsToDelete = utf8::length(deletedPart);
+        if (realMode != LotusMode::Minecraft && realMode != LotusMode::SuperSmooth) {
+            if (ic_->capabilityFlags().test(CapabilityFlag::Url) || isAutofillCertain(ic_->surroundingText())) {
+                ic_->forwardKey(Key(FcitxKey_BackSpace));
+            }
+        }
+        for (size_t i = 0; i < charsToDelete; i++) {
+            ic_->forwardKey(Key(FcitxKey_BackSpace));
+        }
+        if (!addedPart.empty()) {
+            ic_->commitString(addedPart);
+            LOTUS_INFO("Commit: " + addedPart);
+        }
+    }
+
     void LotusState::handleUinputMode(KeyEvent& keyEvent, KeySym currentSym) {
         if (checkForwardSpecialKey(keyEvent, currentSym)) {
             keyEvent.forward();
@@ -598,21 +616,7 @@ namespace fcitx {
 
             if (!deletedPart.empty()) {
                 if (wa_chrome_forwardkey_delete_) {
-                    keyEvent.filterAndAccept();
-                    size_t charsToDelete = utf8::length(deletedPart);
-                    if (realMode != LotusMode::Minecraft && realMode != LotusMode::SuperSmooth) {
-                        // Extra BS dismisses Chrome URL bar inline autocomplete before deleting.
-                        if (ic_->capabilityFlags().test(CapabilityFlag::Url) || isAutofillCertain(ic_->surroundingText())) {
-                            ic_->forwardKey(Key(FcitxKey_BackSpace));
-                        }
-                    }
-                    for (size_t i = 0; i < charsToDelete; i++) {
-                        ic_->forwardKey(Key(FcitxKey_BackSpace));
-                    }
-                    if (!addedPart.empty()) {
-                        ic_->commitString(addedPart);
-                        LOTUS_INFO("Commit: " + addedPart);
-                    }
+                    chromeForwardDelete(keyEvent, deletedPart, addedPart);
                 } else {
                     performReplacement(deletedPart, addedPart);
                     keyEvent.filterAndAccept();
@@ -687,20 +691,7 @@ namespace fcitx {
                 }
             } else {
                 if (wa_chrome_forwardkey_delete_) {
-                    keyEvent.filterAndAccept();
-                    size_t charsToDelete = utf8::length(deletedPart);
-                    if (realMode != LotusMode::Minecraft && realMode != LotusMode::SuperSmooth) {
-                        if (ic_->capabilityFlags().test(CapabilityFlag::Url) || isAutofillCertain(ic_->surroundingText())) {
-                            ic_->forwardKey(Key(FcitxKey_BackSpace));
-                        }
-                    }
-                    for (size_t i = 0; i < charsToDelete; i++) {
-                        ic_->forwardKey(Key(FcitxKey_BackSpace));
-                    }
-                    if (!addedPart.empty()) {
-                        ic_->commitString(addedPart);
-                        LOTUS_INFO("Commit: " + addedPart);
-                    }
+                    chromeForwardDelete(keyEvent, deletedPart, addedPart);
                     oldPreBuffer_ = preeditStr;
                 } else {
                     if (uinput_client_fd_ < 0) {
@@ -752,10 +743,11 @@ namespace fcitx {
             return;
         }
 
-        // Surrounding text lags after a forwarded key; use a fresh engine on the next keystroke.
+        // Surrounding text state is unreliable right after a context switch (Ctrl+Tab, FocusIn+Reset);
+        // forward the key raw so Chrome handles it natively and updates surrounding text correctly.
         if (skipSurrTextRebuild_) {
             skipSurrTextRebuild_ = false;
-            processNormalKey(keyEvent, currentSym);
+            keyEvent.forward();
             return;
         }
 
@@ -1099,8 +1091,13 @@ namespace fcitx {
             }
             ResetEngine(lotusEngine_.handle());
         }
-        if (getFrontendName(ic_) != "dbus")
+        if (getFrontendName(ic_) != "dbus") {
             clearAllBuffers();
+            // InputContextReset arrives after FocusIn on tab switch; re-arm the flag so
+            // the first keystroke is forwarded raw and Chrome can resync surrounding text.
+            if (!isFocusOut)
+                skipSurrTextRebuild_ = true;
+        }
 
         switch (realMode) {
             case LotusMode::Preedit: {

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -597,8 +597,26 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                performReplacement(deletedPart, addedPart);
-                keyEvent.filterAndAccept();
+                if (wa_chrome_forwardkey_delete_) {
+                    keyEvent.filterAndAccept();
+                    size_t charsToDelete = utf8::length(deletedPart);
+                    if (realMode != LotusMode::Minecraft && realMode != LotusMode::SuperSmooth) {
+                        // Extra BS dismisses Chrome URL bar inline autocomplete before deleting.
+                        if (ic_->capabilityFlags().test(CapabilityFlag::Url) || isAutofillCertain(ic_->surroundingText())) {
+                            ic_->forwardKey(Key(FcitxKey_BackSpace));
+                        }
+                    }
+                    for (size_t i = 0; i < charsToDelete; i++) {
+                        ic_->forwardKey(Key(FcitxKey_BackSpace));
+                    }
+                    if (!addedPart.empty()) {
+                        ic_->commitString(addedPart);
+                        LOTUS_INFO("Commit: " + addedPart);
+                    }
+                } else {
+                    performReplacement(deletedPart, addedPart);
+                    keyEvent.filterAndAccept();
+                }
             } else {
                 bool wasAutoCapitalized = (currentSym != keyEvent.rawKey().sym());
                 if (!addedPart.empty() && (keyUtf8 != addedPart || wasAutoCapitalized)) {
@@ -668,29 +686,48 @@ namespace fcitx {
                     keyEvent.forward();
                 }
             } else {
-                if (uinput_client_fd_ < 0) {
-                    LOTUS_ERROR("Cannot connect to uinput server, commit rawkey");
-                    std::string rawKey = keyEvent.key().toString();
-                    if (!rawKey.empty()) {
-                        ic_->commitString(rawKey);
-                    }
-                    return;
-                }
-
-                if (is_deleting_.load()) {
-                    is_deleting_.store(false, std::memory_order_release);
-                }
-
-                if (!wa_chromium_flag)
+                if (wa_chrome_forwardkey_delete_) {
                     keyEvent.filterAndAccept();
-                performReplacement(deletedPart, addedPart);
-                oldPreBuffer_ = preeditStr;
+                    size_t charsToDelete = utf8::length(deletedPart);
+                    if (realMode != LotusMode::Minecraft && realMode != LotusMode::SuperSmooth) {
+                        if (ic_->capabilityFlags().test(CapabilityFlag::Url) || isAutofillCertain(ic_->surroundingText())) {
+                            ic_->forwardKey(Key(FcitxKey_BackSpace));
+                        }
+                    }
+                    for (size_t i = 0; i < charsToDelete; i++) {
+                        ic_->forwardKey(Key(FcitxKey_BackSpace));
+                    }
+                    if (!addedPart.empty()) {
+                        ic_->commitString(addedPart);
+                        LOTUS_INFO("Commit: " + addedPart);
+                    }
+                    oldPreBuffer_ = preeditStr;
+                } else {
+                    if (uinput_client_fd_ < 0) {
+                        LOTUS_ERROR("Cannot connect to uinput server, commit rawkey");
+                        std::string rawKey = keyEvent.key().toString();
+                        if (!rawKey.empty()) {
+                            ic_->commitString(rawKey);
+                        }
+                        return;
+                    }
+
+                    if (is_deleting_.load()) {
+                        is_deleting_.store(false, std::memory_order_release);
+                    }
+
+                    if (!wa_chromium_flag)
+                        keyEvent.filterAndAccept();
+                    performReplacement(deletedPart, addedPart);
+                    oldPreBuffer_ = preeditStr;
+                }
             }
         }
     }
 
     void LotusState::handleSurroundingText(KeyEvent& keyEvent, KeySym currentSym) {
         if (checkForwardSpecialKey(keyEvent, currentSym)) {
+            skipSurrTextRebuild_ = true;
             keyEvent.forward();
             return;
         }
@@ -710,7 +747,15 @@ namespace fcitx {
 
         if (isBackspace(keyEvent.rawKey().sym())) {
             ResetEngine(lotusEngine_.handle());
+            skipSurrTextRebuild_ = true;
             keyEvent.forward();
+            return;
+        }
+
+        // Surrounding text lags after a forwarded key; use a fresh engine on the next keystroke.
+        if (skipSurrTextRebuild_) {
+            skipSurrTextRebuild_ = false;
+            processNormalKey(keyEvent, currentSym);
             return;
         }
 
@@ -786,7 +831,17 @@ namespace fcitx {
                 size_t charsToDelete = utf8::length(deletedPart);
 
                 if (charsToDelete > 0) {
-                    ic->deleteSurroundingText(-static_cast<int>(charsToDelete), static_cast<int>(charsToDelete));
+                    if (wa_chrome_forwardkey_delete_) {
+                        // Chrome ignores deleteSurroundingText when autocomplete is active; extra BS dismisses it.
+                        if (surrounding.anchor() != surrounding.cursor()) {
+                            ic->forwardKey(Key(FcitxKey_BackSpace));
+                        }
+                        for (size_t i = 0; i < charsToDelete; i++) {
+                            ic->forwardKey(Key(FcitxKey_BackSpace));
+                        }
+                    } else {
+                        ic->deleteSurroundingText(-static_cast<int>(charsToDelete), static_cast<int>(charsToDelete));
+                    }
                 }
 
                 if (!addedPart.empty()) {
@@ -1019,7 +1074,14 @@ namespace fcitx {
         size_t      textLen     = utf8::length(text);
         realtextLen.store(textLen, std::memory_order_release);
         if (is_deleting_.load(std::memory_order_acquire)) {
-            return;
+            if (isFocusOut) {
+                return; // Don't interrupt an active uinput deletion sequence during focus-out
+            }
+            is_deleting_.store(false, std::memory_order_release);
+            expected_backspaces_     = 0;
+            current_backspace_count_ = 0;
+            pending_commit_string_.clear();
+            buffered_keys_.clear();
         }
 
         if (lotusEngine_) {
@@ -1113,10 +1175,11 @@ namespace fcitx {
         emojiBuffer_.clear();
         emojiCandidates_.clear();
         buffered_keys_.clear();
-        shouldCapitalize_  = false;
-        isPrevSpace_       = false;
-        isPrevHyphen_      = false;
-        isPrevPunctuation_ = false;
+        shouldCapitalize_    = false;
+        isPrevSpace_         = false;
+        isPrevHyphen_        = false;
+        isPrevPunctuation_   = false;
+        skipSurrTextRebuild_ = false;
         if (lotusEngine_)
             ResetEngine(lotusEngine_.handle());
     }

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -192,6 +192,14 @@ namespace fcitx {
         bool checkForwardSpecialKey(KeyEvent& keyEvent, KeySym& currentSym);
 
         /**
+         * @brief Performs Chrome-specific deletion via forwarded BackSpace keys then commits added text.
+         * @param keyEvent The triggering key event (accepted here).
+         * @param deletedPart Text to delete.
+         * @param addedPart Text to insert after deletion.
+         */
+        void chromeForwardDelete(KeyEvent& keyEvent, const std::string& deletedPart, const std::string& addedPart);
+
+        /**
          * @brief Handles uinput mode processing.
          * @param keyEvent The key event.
          * @param currentSym Current key symbol.

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -99,12 +99,14 @@ namespace fcitx {
         std::vector<EmojiEntry> emojiCandidates_;
         bool                    waitAck_ = false;
         std::vector<KeyEntry>   buffered_keys_; ///< Keystrokes buffered during replacement
-        bool                    isPrevSpace_        = false;
-        bool                    isPrevHyphen_       = false;
-        bool                    shouldCapitalize_   = false;
-        bool                    isPrevPunctuation_  = false;
-        int64_t                 lastDeactivateTime_ = 0;
-        bool                    wa_chromium_flag    = false;
+        bool                    isPrevSpace_                 = false;
+        bool                    isPrevHyphen_                = false;
+        bool                    shouldCapitalize_            = false;
+        bool                    isPrevPunctuation_           = false;
+        int64_t                 lastDeactivateTime_          = 0;
+        bool                    wa_chromium_flag             = false;
+        bool                    wa_chrome_forwardkey_delete_ = false; ///< Chrome: use forwardKey(BackSpace)+commitString instead of async uinput backspaces
+        bool                    skipSurrTextRebuild_         = false; ///< Skip surrounding-text rebuild on the next key after a forwarded BackSpace/special key
 
         /**
          * @brief Connects to the uinput server.


### PR DESCRIPTION
## Mô tả

Sửa lỗi nhập liệu trong Chrome trên Wayland, giải quyết #190.

**Nguyên nhân**: Chrome trên Wayland dùng frontend `waylandim` (`is_dbus = false`), khiến toàn bộ Chrome workaround bị bỏ qua. `deleteSurroundingText` được gọi thay vì `forwardKey(BackSpace)`, dẫn đến double char (`ee` → `eê`) và các hành vi sai khi gõ tiếng Việt.

## Thay đổi

- Tách block SurroundingText mode ra khỏi điều kiện `is_dbus`, kích hoạt `forwardKey(BackSpace)` path cho Chrome trên cả Wayland lẫn dbus
- Extra BackSpace chỉ gửi khi autocomplete thực sự active (`anchor != cursor`), không phải mọi lúc trong URL bar
- Flag `skipSurrTextRebuild_` tránh rebuild engine từ surrounding text cũ ngay sau khi forward BackSpace
- Sau `FocusIn` + `InputContextReset` (Ctrl+Tab), forward key đầu tiên raw thay vì commit qua engine để Chrome resync surrounding text

## Fixes từ code review (Gemini)

- **Bug nghiêm trọng**: `isAutofillCertain` trộn lẫn byte offset (`cursor`/`anchor`) với character count (`utf8::length`); sửa thành `.size()` để thống nhất byte — ảnh hưởng đến tất cả từ tiếng Việt có dấu (multi-byte UTF-8)
- Tương tự, fix `realtextLen` trong `lotus-engine.cpp` dùng `text.size()` thay vì `fcitx_utf8_strlen`
- Đơn giản hoá điều kiện autofill selection: `selectionStart >= cursor || (...)` → `selectionStart == cursor`
- Bỏ `#if __cplusplus >= 202002L` preprocessor block, thay bằng `std::transform` với lambda `[](unsigned char c)` portable trên C++11+
- Extract `chromeForwardDelete()` helper để loại bỏ code trùng lặp ở hai nơi

Closes #190