### PR TITLE
feat: allow macro in Off mode and improve search UI

### DIFF
--- a/settings-gui/ui/helpers.py
+++ b/settings-gui/ui/helpers.py
@@ -28,7 +28,7 @@ HELPERS = {
         "Automatically revert the typed sequence if the resulting word is not in the dictionary.\n"
         "This helps prevent accidental Vietnamese transformations on English words or mixed text."
     ),
-    "EnableMacroInOffMode": _(
+    "EnableMacroInOffMode": N_(
         "Allow macros to work when the input mode is OFF.\n"
         "When disabled, macros are only available in active typing modes."
     ),

--- a/settings-gui/ui/helpers.py
+++ b/settings-gui/ui/helpers.py
@@ -28,6 +28,10 @@ HELPERS = {
         "Automatically revert the typed sequence if the resulting word is not in the dictionary.\n"
         "This helps prevent accidental Vietnamese transformations on English words or mixed text."
     ),
+    "EnableMacroInOffMode": _(
+        "Allow macros to work when the input mode is OFF.\n"
+        "When disabled, macros are only available in active typing modes."
+    ),
 }
 
 

--- a/settings-gui/ui/main_window.py
+++ b/settings-gui/ui/main_window.py
@@ -100,6 +100,7 @@ class LotusSettingsWindow(QMainWindow):
                 border: none;
                 background: transparent;
                 outline: none;
+                padding-top: 15px;
             }
             QListWidget::item {
                 padding: 10px 15px;

--- a/settings-gui/ui/pages/macro_editor.py
+++ b/settings-gui/ui/pages/macro_editor.py
@@ -85,8 +85,6 @@ class MacroEditorPage(BaseEditorPage):
         self.search_input.setClearButtonEnabled(True)
         self.search_input.setFixedWidth(200)
         self.search_input.textChanged.connect(self.on_search_changed)
-        toggles_layout.addWidget(QLabel(_("Search:")))
-        toggles_layout.addWidget(self.search_input)
 
         toggles_card.content_layout.addLayout(toggles_layout)
         main_layout.addWidget(toggles_card)
@@ -221,6 +219,8 @@ class MacroEditorPage(BaseEditorPage):
         toolbar_layout.addWidget(self.btn_up)
         toolbar_layout.addWidget(self.btn_down)
         toolbar_layout.addStretch()
+        toolbar_layout.addWidget(QLabel(_("Search:")))
+        toolbar_layout.addWidget(self.search_input)
 
         content_layout.addLayout(toolbar_layout)
         self.update_button_states()

--- a/settings-gui/ui/pages/macro_editor.py
+++ b/settings-gui/ui/pages/macro_editor.py
@@ -59,8 +59,10 @@ class MacroEditorPage(BaseEditorPage):
         toggles_layout = QHBoxLayout()
         self.cb_enable = QCheckBox(_("Enable Macro"))
         self.cb_capitalize = QCheckBox(_("Capitalize Macro"))
+        self.cb_enable_off_mode = QCheckBox(_("Macro in Off Mode"))
         self.cb_enable.toggled.connect(self._on_item_changed)
         self.cb_capitalize.toggled.connect(self._on_item_changed)
+        self.cb_enable_off_mode.toggled.connect(self._on_item_changed)
         toggles_layout.addWidget(self.cb_enable)
 
         cap_layout = QHBoxLayout()
@@ -69,6 +71,13 @@ class MacroEditorPage(BaseEditorPage):
         add_help_icon(cap_layout, "CapitalizeMacro")
 
         toggles_layout.addLayout(cap_layout)
+
+        off_mode_layout = QHBoxLayout()
+        off_mode_layout.setSpacing(5)
+        off_mode_layout.addWidget(self.cb_enable_off_mode)
+        add_help_icon(off_mode_layout, "EnableMacroInOffMode")
+        toggles_layout.addLayout(off_mode_layout)
+
         toggles_layout.addStretch()
 
         self.search_input = QLineEdit()
@@ -229,6 +238,9 @@ class MacroEditorPage(BaseEditorPage):
                 self.cb_capitalize.setChecked(
                     str(values.get("CapitalizeMacro", "True")).lower() == "true"
                 )
+                self.cb_enable_off_mode.setChecked(
+                    str(values.get("EnableMacroInOffMode", "False")).lower() == "true"
+                )
 
                 # Set time format (default %H:%M)
                 time_fmt = values.get("TimeFormat", "%H:%M")
@@ -266,6 +278,7 @@ class MacroEditorPage(BaseEditorPage):
         try:
             self.cb_enable.setChecked(True)
             self.cb_capitalize.setChecked(True)
+            self.cb_enable_off_mode.setChecked(False)
             self.table.setRowCount(0)
             self._on_item_changed()
         finally:
@@ -278,6 +291,7 @@ class MacroEditorPage(BaseEditorPage):
             self.table.rowCount() > 0
             or not self.cb_enable.isChecked()
             or not self.cb_capitalize.isChecked()
+            or self.cb_enable_off_mode.isChecked()
         )
 
     def is_modified(self):
@@ -301,6 +315,7 @@ class MacroEditorPage(BaseEditorPage):
             "data": data,
             "EnableMacro": self.cb_enable.isChecked(),
             "CapitalizeMacro": self.cb_capitalize.isChecked(),
+            "EnableMacroInOffMode": self.cb_enable_off_mode.isChecked(),
             "TimeFormat": self.input_time_format.currentText(),
             "DateFormat": self.input_date_format.currentText(),
         }
@@ -313,6 +328,9 @@ class MacroEditorPage(BaseEditorPage):
             values["EnableMacro"] = "True" if self.cb_enable.isChecked() else "False"
             values["CapitalizeMacro"] = (
                 "True" if self.cb_capitalize.isChecked() else "False"
+            )
+            values["EnableMacroInOffMode"] = (
+                "True" if self.cb_enable_off_mode.isChecked() else "False"
             )
             values["TimeFormat"] = self.input_time_format.currentText()
             values["DateFormat"] = self.input_date_format.currentText()

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -248,6 +248,7 @@ namespace fcitx {
         Option<std::string> shortcutEmoji{this, "ShortcutEmoji", _("Shortcut for Emoji Picker"), "w"}; Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true};
         Option<std::string> shortcutOff{this, "ShortcutOff", _("Shortcut for OFF"), "e"}; Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
         Option<std::string> shortcutDefault{this, "ShortcutDefault", _("Shortcut for Default Typing"), "r"};
+        Option<bool>                                                                     enableMacroInOffMode{this, "EnableMacroInOffMode", _("Allow Macro in Off Mode"), false};
 
         Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default"};
 

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -248,7 +248,7 @@ namespace fcitx {
         Option<std::string> shortcutEmoji{this, "ShortcutEmoji", _("Shortcut for Emoji Picker"), "w"}; Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true};
         Option<std::string> shortcutOff{this, "ShortcutOff", _("Shortcut for OFF"), "e"}; Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
         Option<std::string> shortcutDefault{this, "ShortcutDefault", _("Shortcut for Default Typing"), "r"};
-        Option<bool>                                                                     enableMacroInOffMode{this, "EnableMacroInOffMode", _("Allow Macro in Off Mode"), false};
+        Option<bool>        enableMacroInOffMode{this, "EnableMacroInOffMode", _("Allow Macro in Off Mode"), false};
 
         Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default"};
 

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -1093,6 +1093,9 @@ namespace fcitx {
     void LotusEngine::setMode(LotusMode mode, InputContext* ic) {
         realMode = mode;
         if (ic != nullptr) {
+            if (auto* state = ic->propertyFor(&factory_)) {
+                state->clearAllBuffers();
+            }
             ic->updateUserInterface(UserInterfaceComponent::StatusArea);
         }
     }

--- a/src/lotus-engine.h
+++ b/src/lotus-engine.h
@@ -326,7 +326,7 @@ namespace fcitx {
          * @param mode The mode to set.
          * @param ic Current input context.
          */
-        static void setMode(LotusMode mode, InputContext* ic);
+        void setMode(LotusMode mode, InputContext* ic);
 
         /**
          * @brief Get name of current program

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -870,18 +870,15 @@ namespace fcitx {
     }
 
     void LotusState::handleOffModeMacro(KeyEvent& keyEvent, KeySym currentSym) {
-        // 1. Special keys: Tab, arrows, Escape, modifiers, Delete → forward + reset
         if (checkForwardSpecialKey(keyEvent, currentSym)) {
             keyEvent.forward();
             return;
         }
 
-        // 2. Try to ensure uinput is available for potential replacement
         if (uinput_client_fd_ < 0) {
             connect_uinput_server();
         }
 
-        // 3. Backspace → feed to engine for shadow state tracking, then forward
         if (isBackspace(currentSym)) {
             EngineProcessKeyEvent(lotusEngine_.handle(), FcitxKey_BackSpace, 0);
             auto preeditC = UniqueCPtr<char>(EnginePullPreedit(lotusEngine_.handle()));
@@ -890,7 +887,6 @@ namespace fcitx {
             return;
         }
 
-        // 4. Return/Enter → forward, clear shadow state
         if (currentSym == FcitxKey_Return) {
             if (!oldPreBuffer_.empty()) {
                 ResetEngine(lotusEngine_.handle());
@@ -900,19 +896,16 @@ namespace fcitx {
             return;
         }
 
-        // 5. Get UTF-8 representation of the trigger key
         std::string keyUtf8 = Key::keySymToUTF8(currentSym);
 
-        // 6. Process key through Go engine (shadow processing)
-        bool processed = EngineProcessKeyEvent(lotusEngine_.handle(), currentSym, keyEvent.rawKey().states()) != 0U;
+        bool        processed = EngineProcessKeyEvent(lotusEngine_.handle(), currentSym, keyEvent.rawKey().states()) != 0U;
 
-        // 7. Check for engine commit
-        auto commitPtr = UniqueCPtr<char>(EnginePullCommit(lotusEngine_.handle()));
+        auto        commitPtr = UniqueCPtr<char>(EnginePullCommit(lotusEngine_.handle()));
         if (processed && commitPtr && (*commitPtr.get() != 0)) {
             std::string commitStr = commitPtr.get();
 
             // Determine if this is a macro expansion or just confirmed typed text
-            bool isMacroExpansion;
+            bool isMacroExpansion = false;
             if (keyUtf8.empty()) {
                 isMacroExpansion = (commitStr != oldPreBuffer_);
             } else {

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -869,6 +869,108 @@ namespace fcitx {
         }
     }
 
+    void LotusState::handleOffModeMacro(KeyEvent& keyEvent, KeySym currentSym) {
+        // 1. Special keys: Tab, arrows, Escape, modifiers, Delete → forward + reset
+        if (checkForwardSpecialKey(keyEvent, currentSym)) {
+            keyEvent.forward();
+            return;
+        }
+
+        // 2. Try to ensure uinput is available for potential replacement
+        if (uinput_client_fd_ < 0) {
+            connect_uinput_server();
+        }
+
+        // 3. Backspace → feed to engine for shadow state tracking, then forward
+        if (isBackspace(currentSym)) {
+            EngineProcessKeyEvent(lotusEngine_.handle(), FcitxKey_BackSpace, 0);
+            auto preeditC = UniqueCPtr<char>(EnginePullPreedit(lotusEngine_.handle()));
+            oldPreBuffer_ = (preeditC && (*preeditC.get() != 0)) ? preeditC.get() : "";
+            keyEvent.forward();
+            return;
+        }
+
+        // 4. Return/Enter → forward, clear shadow state
+        if (currentSym == FcitxKey_Return) {
+            if (!oldPreBuffer_.empty()) {
+                ResetEngine(lotusEngine_.handle());
+                oldPreBuffer_.clear();
+            }
+            keyEvent.forward();
+            return;
+        }
+
+        // 5. Get UTF-8 representation of the trigger key
+        std::string keyUtf8 = Key::keySymToUTF8(currentSym);
+
+        // 6. Process key through Go engine (shadow processing)
+        bool processed = EngineProcessKeyEvent(lotusEngine_.handle(), currentSym, keyEvent.rawKey().states()) != 0U;
+
+        // 7. Check for engine commit
+        auto commitPtr = UniqueCPtr<char>(EnginePullCommit(lotusEngine_.handle()));
+        if (processed && commitPtr && (*commitPtr.get() != 0)) {
+            std::string commitStr = commitPtr.get();
+
+            // Determine if this is a macro expansion or just confirmed typed text
+            bool isMacroExpansion;
+            if (keyUtf8.empty()) {
+                isMacroExpansion = (commitStr != oldPreBuffer_);
+            } else {
+                isMacroExpansion = (commitStr != oldPreBuffer_ + keyUtf8);
+            }
+
+            if (isMacroExpansion) {
+                LOTUS_INFO("Macro expansion: '" + oldPreBuffer_ + "' -> '" + commitStr + "'");
+                // Try uinput replacement first, fallback to deleteSurroundingText, then plain commit
+                if (uinput_client_fd_ >= 0 && !oldPreBuffer_.empty()) {
+                    performReplacement(oldPreBuffer_, commitStr);
+                } else if (ic_->capabilityFlags().test(CapabilityFlag::SurroundingText)) {
+                    const auto& surrounding = ic_->surroundingText();
+                    if (surrounding.isValid()) {
+                        size_t oldLen = utf8::length(oldPreBuffer_);
+                        if (oldLen > 0) {
+                            ic_->deleteSurroundingText(-static_cast<int>(oldLen), static_cast<int>(oldLen));
+                        }
+                        ic_->commitString(commitStr);
+                    } else {
+                        ic_->commitString(commitStr);
+                    }
+                } else {
+                    ic_->commitString(commitStr);
+                }
+                keyEvent.filterAndAccept();
+            } else {
+                // No macro: typed text confirmed by engine, just forward trigger key
+                keyEvent.forward();
+            }
+
+            oldPreBuffer_.clear();
+            hasHistory_ = false;
+            return;
+        }
+
+        // 8. No commit or engine rejected the key
+        if (processed || (commitPtr && (*commitPtr.get() != 0))) {
+            // Engine processed the key (building shadow state)
+            // OR engine rejected the key but committed old text (non-processable key)
+            auto preeditPtr = UniqueCPtr<char>(EnginePullPreedit(lotusEngine_.handle()));
+            oldPreBuffer_   = (preeditPtr && (*preeditPtr.get() != 0)) ? preeditPtr.get() : "";
+            if (!processed) {
+                // Engine committed old text but didn't process the new key → forward the key
+                oldPreBuffer_.clear();
+                hasHistory_ = false;
+            }
+            keyEvent.forward();
+        } else {
+            // Engine didn't handle this key
+            if (!oldPreBuffer_.empty()) {
+                ResetEngine(lotusEngine_.handle());
+                oldPreBuffer_.clear();
+            }
+            keyEvent.forward();
+        }
+    }
+
     void LotusState::keyEvent(KeyEvent& keyEvent) {
         if (!lotusEngine_ || keyEvent.isRelease() || keyEvent.rawKey().isModifier())
             return;
@@ -1008,6 +1110,9 @@ namespace fcitx {
                 break;
             }
             default: {
+                if (*engine_->config().enableMacroInOffMode && *engine_->config().enableMacro) {
+                    handleOffModeMacro(keyEvent, currentSym);
+                }
                 break;
             }
         }

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -1141,6 +1141,8 @@ namespace fcitx {
                 }
             }
             ResetEngine(lotusEngine_.handle());
+            oldPreBuffer_.clear();
+            hasHistory_ = false;
         }
         if (getFrontendName(ic_) != "dbus")
             clearAllBuffers();

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -205,10 +205,17 @@ namespace fcitx {
         void handleSurroundingText(KeyEvent& keyEvent, KeySym currentSym);
 
         /**
+         * @brief Handles Off mode with macro shadow processing.
+         * @param keyEvent The key event.
+         * @param currentSym Current key symbol.
+         */
+        void handleOffModeMacro(KeyEvent& keyEvent, KeySym currentSym);
+
+        /**
          * @brief Handles processing normal key events.
          * @param keyEvent The key event.
          * @param currentSym Current key symbol.
-        */
+         */
         void processNormalKey(KeyEvent& keyEvent, KeySym currentSym);
 
         /**


### PR DESCRIPTION
## What

1. Adds an option `EnableMacroInOffMode` to allow macro processing even when the input method is in "Off" mode.
2. In the settings GUI, moves the macro search bar from the top toggles layout to the bottom toolbar on the right.

## Why

1. Users may want to trigger text expansion/macros even when Vietnamese input is toggled off.
2. Grouping the search input in the bottom toolbar alongside other list actions makes the settings UI more consistent.

## How tested

1. Verified settings-gui compilation.
2. Manual verification of GUI layout behavior.