### PR TITLE
fix: Chromium input handling for uinput mode on Wayland frontend

### DIFF
--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -1129,10 +1129,16 @@ namespace fcitx {
     }
 
     void LotusEngine::setMode(LotusMode mode, InputContext* ic) {
-        realMode = mode;
+        // Only clear on an actual mode switch. activate() calls setMode() on
+        // every FocusIn, and web editors (MS365) refocus after each replacement:
+        // clearing unconditionally wipes the compose state mid-word.
+        const bool modeChanged = (realMode != mode);
+        realMode               = mode;
         if (ic != nullptr) {
-            if (auto* state = ic->propertyFor(&factory_)) {
-                state->clearAllBuffers();
+            if (modeChanged) {
+                if (auto* state = ic->propertyFor(&factory_)) {
+                    state->clearAllBuffers();
+                }
             }
             ic->updateUserInterface(UserInterfaceComponent::StatusArea);
         }

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -770,13 +770,7 @@ namespace fcitx {
                 state->lastDeactivateTime_ = now_ms();
                 LOTUS_INFO("Skip clearAllBuffers");
             } else {
-                // Clear on a genuine focus-out, but not one that immediately follows
-                // our own forwarded edit (e.g. MS365 recreating its field after a
-                // replacement) — that guard mirrors reset()/activate() below and
-                // keeps mid-word compose state alive for that case. A real
-                // Alt-Tab away leaves oldPreBuffer_ stale otherwise, corrupting the
-                // next word typed after switching back (e.g. into Chrome).
-                if (surrvalid && (now_ms() - state->lastSelfEditTime_) >= LotusState::kSelfEditResetGuardMs)
+                if (surrvalid && state->oldPreBuffer_.empty())
                     state->clearAllBuffers();
             }
             is_deleting_.store(false);

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -743,7 +743,11 @@ namespace fcitx {
             return;
         }
         // InputContextReset (e.g., Chrome Ctrl+Tab) must bypass the history guard or the engine stays stale.
-        if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut && event.type() != EventType::InputContextReset) {
+        // Scope the bypass to chromium-family apps only: non-ack apps (Firefox, etc.) can fire
+        // InputContextReset mid-word during normal typing, and resetting the engine there wipes
+        // compose state, causing the next key to fall through as a raw, unconverted keystroke.
+        const bool chromiumResetBypass = event.type() == EventType::InputContextReset && state->wa_chromium_flag;
+        if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut && !chromiumResetBypass) {
             return;
         }
 

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -770,7 +770,13 @@ namespace fcitx {
                 state->lastDeactivateTime_ = now_ms();
                 LOTUS_INFO("Skip clearAllBuffers");
             } else {
-                if (surrvalid && state->oldPreBuffer_.empty())
+                // Clear on a genuine focus-out, but not one that immediately follows
+                // our own forwarded edit (e.g. MS365 recreating its field after a
+                // replacement) — that guard mirrors reset()/activate() below and
+                // keeps mid-word compose state alive for that case. A real
+                // Alt-Tab away leaves oldPreBuffer_ stale otherwise, corrupting the
+                // next word typed after switching back (e.g. into Chrome).
+                if (surrvalid && (now_ms() - state->lastSelfEditTime_) >= LotusState::kSelfEditResetGuardMs)
                     state->clearAllBuffers();
             }
             is_deleting_.store(false);

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -383,9 +383,10 @@ namespace fcitx {
     }
 
     void LotusEngine::activate(const InputMethodEntry& /*entry*/, InputContextEvent& event) {
-        auto*                    ic        = event.inputContext();
-        const bool               surrvalid = ic->surroundingText().isValid();
-        const bool               is_dbus   = getFrontendName(ic) == "dbus";
+        auto*                    ic         = event.inputContext();
+        const bool               surrvalid  = ic->surroundingText().isValid();
+        const bool               is_dbus    = getFrontendName(ic) == "dbus";
+        const bool               is_wayland = getFrontendName(ic) == "wayland";
         static std::atomic<bool> mouseThreadStarted{false};
         if (!mouseThreadStarted.exchange(true))
             startMouseReset();
@@ -414,32 +415,56 @@ namespace fcitx {
         // it not support surrounding text so can't know when it show suggestions
         //
         // TODO: Properly fixes instead ugly WA
-        state->wa_chromium_flag = false;
+        state->wa_chromium_flag             = false;
+        state->wa_chrome_forwardkey_delete_ = false;
 
         state->waitAck_ = false;
-        if (*config_.fixUinputWithAck) {
-            if (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth) {
-#if __cplusplus >= 202002L
-                std::ranges::transform(appName, appName.begin(), ::tolower);
-#else
-                std::transform(appName.begin(), appName.end(), appName.begin(), ::tolower);
-#endif
-                for (const auto& ackApp : ack_apps) {
-                    if (appName.find(ackApp) != std::string::npos) {
-                        if (is_dbus) {
-                            state->waitAck_ = true;
-                            LOTUS_INFO(ackApp + " detected, waiting for ack");
-                        }
-                        state->wa_chromium_flag = true;
-                        break;
+
+        std::string appNameLower = appName;
+        std::transform(appNameLower.begin(), appNameLower.end(), appNameLower.begin(), [](unsigned char c) { return std::tolower(c); });
+
+        // Wayland frontend needs the same chromium workarounds as dbus: uinput
+        // backspaces race against text-input commits inside chromium's pipeline.
+        if ((is_dbus || is_wayland) &&
+            (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth)) {
+            for (const auto& ackApp : ack_apps) {
+                if (appNameLower.find(ackApp) != std::string::npos) {
+                    state->wa_chromium_flag             = true;
+                    state->wa_chrome_forwardkey_delete_ = true;
+                    if (*config_.fixUinputWithAck) {
+                        state->waitAck_ = true;
+                        LOTUS_INFO(ackApp + " detected, waiting for ack");
+                    } else {
+                        LOTUS_INFO(ackApp + " detected, using commit+forwardKey workaround");
                     }
+                    break;
+                }
+            }
+        }
+        // Chromium drops the first commitString after FocusIn (tab/window
+        // switch) while its renderer re-binds the IME; deliver that key raw.
+        if (state->wa_chromium_flag && event.type() == EventType::InputContextFocusIn) {
+            state->forwardNextKeyRaw_ = true;
+        }
+        // Chrome ignores deleteSurroundingText when URL bar autocomplete is active; use forwardKey.
+        if (targetMode == LotusMode::SurroundingText) {
+            for (const auto& ackApp : ack_apps) {
+                if (appNameLower.find(ackApp) != std::string::npos) {
+                    state->wa_chrome_forwardkey_delete_ = true;
+                    LOTUS_INFO(ackApp + " detected in SurroundingText mode, using forwardKey for delete");
+                    break;
                 }
             }
         }
         if (event.type() == EventType::InputContextFocusIn && is_dbus && !surrvalid) {
             LOTUS_INFO("Skip clearAllBuffers");
-        } else if (surrvalid && !state->oldPreBuffer_.empty() && (now_ms() - state->lastDeactivateTime_) < 100) {
+        } else if (surrvalid && !state->oldPreBuffer_.empty() && (now_ms() - state->lastDeactivateTime_) < 100 &&
+                   (now_ms() - state->lastSelfEditTime_) >= LotusState::kSelfEditResetGuardMs) {
             state->clearAllBuffers();
+        }
+        // After focus-in, forward the first key raw so Chrome updates surrounding text before engine rebuild.
+        if (event.type() == EventType::InputContextFocusIn && targetMode == LotusMode::SurroundingText) {
+            state->skipSurrTextRebuild_ = true;
         }
         is_deleting_.store(false);
         needEngineReset.store(false);
@@ -701,7 +726,7 @@ namespace fcitx {
         state->keyEvent(keyEvent);
         const auto&  s       = ic->surroundingText();
         const auto&  text    = s.text();
-        size_t       textLen = fcitx_utf8_strlen(text.c_str());
+        size_t       textLen = text.size(); // byte length, matches cursor which is a byte offset
         unsigned int cursor  = s.cursor();
         if (textLen == static_cast<size_t>(cursor))
             realtextLen.store(static_cast<unsigned int>(textLen), std::memory_order_release);
@@ -710,12 +735,25 @@ namespace fcitx {
     void LotusEngine::reset(const InputMethodEntry& /*entry*/, InputContextEvent& event) {
         LOTUS_INFO("Reset engine");
         auto* state = event.inputContext()->propertyFor(&factory_);
-        if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut) {
+        // Chromium fires FocusOut/Reset milliseconds after our own forwarded
+        // BackSpace+commit (e.g. MS365 recreates its edit field); honoring it
+        // would wipe the compose state right before the word's tone key.
+        if (now_ms() - state->lastSelfEditTime_ < LotusState::kSelfEditResetGuardMs) {
+            LOTUS_INFO("Skip reset right after self edit");
+            return;
+        }
+        // InputContextReset (e.g., Chrome Ctrl+Tab) must bypass the history guard or the engine stays stale.
+        if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut && event.type() != EventType::InputContextReset) {
             return;
         }
 
         if (event.type() == EventType::InputContextFocusOut || event.type() == EventType::InputContextReset) {
             state->reset(event.type() == EventType::InputContextFocusOut);
+            // Chromium re-binds its IME after the reset and drops the first
+            // commitString; have the next key delivered raw to bridge the gap.
+            if (state->wa_chromium_flag) {
+                state->forwardNextKeyRaw_ = true;
+            }
         }
     }
 

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -564,7 +564,12 @@ namespace fcitx {
         keyEvent.filterAndAccept();
         size_t charsToDelete = utf8::length(deletedPart);
         if (realMode != LotusMode::Minecraft && realMode != LotusMode::SuperSmooth) {
-            if (ic_->capabilityFlags().test(CapabilityFlag::Url) || isAutofillCertain(ic_->surroundingText())) {
+            // CapabilityFlag::Url is static (always set for the address bar) and does not
+            // indicate an actual autofill/ghost-suggestion is showing; relying on it alone
+            // sends a spurious extra backspace on every replacement, eating a real character
+            // (e.g. "nguyễn" -> "ngễn"). Only add it when isAutofillCertain() finds real
+            // evidence of autofill, matching handleSurroundingText's anchor()!=cursor() check.
+            if (isAutofillCertain(ic_->surroundingText())) {
                 ic_->forwardKey(Key(FcitxKey_BackSpace));
             }
         }

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -1206,7 +1206,8 @@ namespace fcitx {
     void LotusState::reset(bool isFocusOut) {
         const auto& surrounding = ic_->surroundingText();
         const auto& text        = surrounding.text();
-        size_t      textLen     = utf8::length(text);
+        // Byte length: realtextLen is compared against cursor(), a byte offset in text-input-v3.
+        size_t textLen = text.size();
         realtextLen.store(textLen, std::memory_order_release);
         if (is_deleting_.load(std::memory_order_acquire)) {
             if (isFocusOut) {

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -11,6 +11,7 @@
 #include "lotus-candidates.h"
 #include "lotus-utils.h"
 #include "lotus.h"
+#include "ack-apps.h"
 
 #include <cstddef>
 #include <fcitx-utils/log.h>
@@ -144,13 +145,13 @@ namespace fcitx {
             return false;
         }
 
-        const unsigned int cursor  = s.cursor();
-        const unsigned int anchor  = s.anchor();
-        const auto&        text    = s.text();
-        const size_t       textLen = utf8::length(text);
+        const unsigned int cursor = s.cursor();
+        const unsigned int anchor = s.anchor();
+        const auto&        text   = s.text();
+        // Use byte lengths to match cursor/anchor which are byte offsets in text-input-v3.
+        const size_t textLen = text.size();
+        const size_t buffLen = oldPreBuffer_.size();
 
-        // Fix that surrounding text is delay update
-        const size_t buffLen    = utf8::length(oldPreBuffer_);
         const size_t pb         = text.find(oldPreBuffer_);
         size_t       rangeStart = static_cast<size_t>(cursor) >= buffLen ? static_cast<size_t>(cursor) - buffLen : 0;
         const bool   sameprefix = pb != std::string::npos && pb >= rangeStart && pb <= static_cast<size_t>(cursor);
@@ -162,7 +163,8 @@ namespace fcitx {
 
             // Only consider it browser autofill if the selection starts at the cursor
             // and extends to the end of the line (common address bar behavior).
-            if (selectionStart >= cursor || (selectionStart < cursor && selectionEnd > cursor)) {
+            // selectionStart == cursor means anchor > cursor (selection extends forward).
+            if (selectionStart == cursor) {
                 if (!sameprefix)
                     return false;
                 // If the selection contains a newline, it's likely a multiline editor (AI ghost text),
@@ -173,7 +175,7 @@ namespace fcitx {
         }
 
         if (textLen == static_cast<size_t>(cursor)) {
-            realtextLen.store(textLen, std::memory_order_release);
+            realtextLen.store(static_cast<unsigned int>(textLen), std::memory_order_release);
             return false;
         }
 
@@ -460,6 +462,7 @@ namespace fcitx {
             }
             ic_->commitString(pending_commit_string_);
             LOTUS_INFO("Commit: " + pending_commit_string_);
+            lastSelfEditTime_        = now_ms();
             expected_backspaces_     = 0;
             current_backspace_count_ = 0;
             pending_commit_string_.clear();
@@ -556,7 +559,53 @@ namespace fcitx {
         return false;
     }
 
+    void LotusState::chromeForwardDelete(KeyEvent& keyEvent, const std::string& deletedPart, const std::string& addedPart) {
+        keyEvent.filterAndAccept();
+        size_t charsToDelete = utf8::length(deletedPart);
+        if (realMode != LotusMode::Minecraft && realMode != LotusMode::SuperSmooth) {
+            if (ic_->capabilityFlags().test(CapabilityFlag::Url) || isAutofillCertain(ic_->surroundingText())) {
+                ic_->forwardKey(Key(FcitxKey_BackSpace));
+            }
+        }
+        for (size_t i = 0; i < charsToDelete; i++) {
+            ic_->forwardKey(Key(FcitxKey_BackSpace));
+        }
+        if (!addedPart.empty()) {
+            ic_->commitString(addedPart);
+            LOTUS_INFO("Commit: " + addedPart);
+        }
+        lastSelfEditTime_ = now_ms();
+    }
+
+    void LotusState::ensureChromiumWorkarounds() {
+        if (wa_chromium_flag || ackAppCached_ == 0) {
+            return;
+        }
+        if (ackAppCached_ == -1) {
+            std::string appNameLower = ic_->program();
+            std::transform(appNameLower.begin(), appNameLower.end(), appNameLower.begin(), [](unsigned char c) { return std::tolower(c); });
+            ackAppCached_ = 0;
+            for (const auto& ackApp : ack_apps) {
+                if (appNameLower.find(ackApp) != std::string::npos) {
+                    ackAppCached_ = 1;
+                    break;
+                }
+            }
+        }
+        if (ackAppCached_ == 1) {
+            const std::string frontend = getFrontendName(ic_);
+            if (frontend == "dbus" || frontend == "wayland") {
+                wa_chromium_flag             = true;
+                wa_chrome_forwardkey_delete_ = true;
+                waitAck_                     = *engine_->config().fixUinputWithAck;
+                forwardNextKeyRaw_           = true;
+                LOTUS_INFO("Chromium app detected on first key, enabling workarounds");
+            }
+        }
+    }
+
     void LotusState::handleUinputMode(KeyEvent& keyEvent, KeySym currentSym) {
+        ensureChromiumWorkarounds();
         if (checkForwardSpecialKey(keyEvent, currentSym)) {
             keyEvent.forward();
             return;
@@ -597,8 +646,12 @@ namespace fcitx {
             compareAndSplitStrings(oldPreBuffer_, commitStr, deletedPart, addedPart);
 
             if (!deletedPart.empty()) {
-                performReplacement(deletedPart, addedPart);
-                keyEvent.filterAndAccept();
+                if (wa_chrome_forwardkey_delete_) {
+                    chromeForwardDelete(keyEvent, deletedPart, addedPart);
+                } else {
+                    performReplacement(deletedPart, addedPart);
+                    keyEvent.filterAndAccept();
+                }
             } else {
                 bool wasAutoCapitalized = (currentSym != keyEvent.rawKey().sym());
                 if (!addedPart.empty() && (keyUtf8 != addedPart || wasAutoCapitalized)) {
@@ -646,7 +699,17 @@ namespace fcitx {
         std::string      deletedPart;
         std::string      addedPart;
 
-        if (wa_chromium_flag)
+        // Chromium silently drops the first commitString right after a tab
+        // switch (Ctrl+Tab/FocusIn) while its renderer re-binds the IME.
+        // Deliver that key as a raw event instead: Chrome inserts it natively
+        // and the raw key completes the IME re-bind.
+        bool firstKeyRaw = false;
+        if (forwardNextKeyRaw_) {
+            forwardNextKeyRaw_ = false;
+            firstKeyRaw        = wa_chromium_flag && oldPreBuffer_.empty() && !keyEvent.key().hasModifier();
+        }
+
+        if (wa_chromium_flag && !firstKeyRaw)
             keyEvent.filterAndAccept();
 
         if (compareAndSplitStrings(oldPreBuffer_, preeditStr, deletedPart, addedPart) != 0) {
@@ -655,9 +718,13 @@ namespace fcitx {
                 bool wasAutoCapitalized = (currentSym != keyEvent.rawKey().sym());
                 if (!addedPart.empty()) {
                     oldPreBuffer_ = preeditStr;
-                    if (wa_chromium_flag || wasAutoCapitalized || addedPart != keyUtf8) {
+                    if (firstKeyRaw && !wasAutoCapitalized && addedPart == keyUtf8) {
+                        keyEvent.forward();
+                        isCommit = true;
+                    } else if (wa_chromium_flag || wasAutoCapitalized || addedPart != keyUtf8) {
                         ic_->commitString(addedPart);
                         LOTUS_INFO("Commit: " + addedPart);
+                        lastSelfEditTime_ = now_ms();
                         if (!wa_chromium_flag) {
                             keyEvent.filterAndAccept();
                             isCommit = true;
@@ -668,29 +735,35 @@ namespace fcitx {
                     keyEvent.forward();
                 }
             } else {
-                if (uinput_client_fd_ < 0) {
-                    LOTUS_ERROR("Cannot connect to uinput server, commit rawkey");
-                    std::string rawKey = keyEvent.key().toString();
-                    if (!rawKey.empty()) {
-                        ic_->commitString(rawKey);
+                if (wa_chrome_forwardkey_delete_) {
+                    chromeForwardDelete(keyEvent, deletedPart, addedPart);
+                    oldPreBuffer_ = preeditStr;
+                } else {
+                    if (uinput_client_fd_ < 0) {
+                        LOTUS_ERROR("Cannot connect to uinput server, commit rawkey");
+                        std::string rawKey = keyEvent.key().toString();
+                        if (!rawKey.empty()) {
+                            ic_->commitString(rawKey);
+                        }
+                        return;
                     }
-                    return;
-                }
 
-                if (is_deleting_.load()) {
-                    is_deleting_.store(false, std::memory_order_release);
-                }
+                    if (is_deleting_.load()) {
+                        is_deleting_.store(false, std::memory_order_release);
+                    }
 
-                if (!wa_chromium_flag)
-                    keyEvent.filterAndAccept();
-                performReplacement(deletedPart, addedPart);
-                oldPreBuffer_ = preeditStr;
+                    if (!wa_chromium_flag)
+                        keyEvent.filterAndAccept();
+                    performReplacement(deletedPart, addedPart);
+                    oldPreBuffer_ = preeditStr;
+                }
             }
         }
     }
 
     void LotusState::handleSurroundingText(KeyEvent& keyEvent, KeySym currentSym) {
         if (checkForwardSpecialKey(keyEvent, currentSym)) {
+            skipSurrTextRebuild_ = true;
             keyEvent.forward();
             return;
         }
@@ -710,6 +783,15 @@ namespace fcitx {
 
         if (isBackspace(keyEvent.rawKey().sym())) {
             ResetEngine(lotusEngine_.handle());
+            skipSurrTextRebuild_ = true;
+            keyEvent.forward();
+            return;
+        }
+
+        // Surrounding text state is unreliable right after a context switch (Ctrl+Tab, FocusIn+Reset);
+        // forward the key raw so Chrome handles it natively and updates surrounding text correctly.
+        if (skipSurrTextRebuild_) {
+            skipSurrTextRebuild_ = false;
             keyEvent.forward();
             return;
         }
@@ -786,7 +868,17 @@ namespace fcitx {
                 size_t charsToDelete = utf8::length(deletedPart);
 
                 if (charsToDelete > 0) {
-                    ic->deleteSurroundingText(-static_cast<int>(charsToDelete), static_cast<int>(charsToDelete));
+                    if (wa_chrome_forwardkey_delete_) {
+                        // Chrome ignores deleteSurroundingText when autocomplete is active; extra BS dismisses it.
+                        if (surrounding.anchor() != surrounding.cursor()) {
+                            ic->forwardKey(Key(FcitxKey_BackSpace));
+                        }
+                        for (size_t i = 0; i < charsToDelete; i++) {
+                            ic->forwardKey(Key(FcitxKey_BackSpace));
+                        }
+                    } else {
+                        ic->deleteSurroundingText(-static_cast<int>(charsToDelete), static_cast<int>(charsToDelete));
+                    }
                 }
 
                 if (!addedPart.empty()) {
@@ -1117,7 +1209,14 @@ namespace fcitx {
         size_t      textLen     = utf8::length(text);
         realtextLen.store(textLen, std::memory_order_release);
         if (is_deleting_.load(std::memory_order_acquire)) {
-            return;
+            if (isFocusOut) {
+                return; // Don't interrupt an active uinput deletion sequence during focus-out
+            }
+            is_deleting_.store(false, std::memory_order_release);
+            expected_backspaces_     = 0;
+            current_backspace_count_ = 0;
+            pending_commit_string_.clear();
+            buffered_keys_.clear();
         }
 
         if (lotusEngine_) {
@@ -1137,8 +1236,13 @@ namespace fcitx {
             oldPreBuffer_.clear();
             hasHistory_ = false;
         }
-        if (getFrontendName(ic_) != "dbus")
+        if (getFrontendName(ic_) != "dbus") {
             clearAllBuffers();
+            // InputContextReset arrives after FocusIn on tab switch; re-arm the flag so
+            // the first keystroke is forwarded raw and Chrome can resync surrounding text.
+            if (!isFocusOut)
+                skipSurrTextRebuild_ = true;
+        }
 
         switch (realMode) {
             case LotusMode::Preedit: {
@@ -1213,10 +1317,11 @@ namespace fcitx {
         emojiBuffer_.clear();
         emojiCandidates_.clear();
         buffered_keys_.clear();
-        shouldCapitalize_  = false;
-        isPrevSpace_       = false;
-        isPrevHyphen_      = false;
-        isPrevPunctuation_ = false;
+        shouldCapitalize_    = false;
+        isPrevSpace_         = false;
+        isPrevHyphen_        = false;
+        isPrevPunctuation_   = false;
+        skipSurrTextRebuild_ = false;
         if (lotusEngine_)
             ResetEngine(lotusEngine_.handle());
     }

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -1114,6 +1114,13 @@ namespace fcitx {
         if (g_mouse_clicked.load(std::memory_order_acquire) && !is_deleting_.load(std::memory_order_acquire)) {
             g_mouse_clicked.store(false, std::memory_order_release);
             clearAllBuffers();
+            // forwardNextKeyRaw_ is meant to bridge Chrome's IME re-bind gap after a
+            // keyboard-driven tab switch (Ctrl+Tab). A mouse click already gives Chrome
+            // a real focus/cursor signal, so the raw-key nudge isn't needed here — and
+            // forwarding the first key raw while the rest commit via commitString mixes
+            // two input channels that React-controlled contenteditable (e.g. Facebook)
+            // doesn't reconcile reliably, corrupting the word being typed.
+            forwardNextKeyRaw_ = false;
         }
         KeySym currentSym = keyEvent.rawKey().sym();
         if (*engine_->config().autoCapitalizeAfterPunctuation && realMode != LotusMode::Off) {

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -485,11 +485,12 @@ namespace fcitx {
             ++expected_backspaces_;
             if (realMode != LotusMode::SuperSmooth) {
                 const auto& surrounding = ic_->surroundingText();
-                // Enable Autofill detection for all frontends (Wayland/IBus).
-                // This fixes the "toôi" duplication bug in Chromium-based search bars.
-                // The isAutofillCertain function has been optimized to differentiate
-                // between browser autofill and AI ghost text.
-                if (isAutofillCertain(surrounding)) {
+                // Autofill detection fixes the "toôi" duplication bug in
+                // Chromium-based search bars, so only apply it to chromium-family
+                // apps: in code editors (VSCode/Monaco) text after the cursor on
+                // the same line is normal, and the heuristic would add a spurious
+                // extra backspace that eats a real character.
+                if (ackAppCached_ == 1 && isAutofillCertain(surrounding)) {
                     ++expected_backspaces_;
                 }
             }

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -573,8 +573,22 @@ namespace fcitx {
                 ic_->forwardKey(Key(FcitxKey_BackSpace));
             }
         }
-        for (size_t i = 0; i < charsToDelete; i++) {
-            ic_->forwardKey(Key(FcitxKey_BackSpace));
+        // Prefer deleteSurroundingText over forwardKey(BackSpace) for the actual
+        // replacement: it stays on the same text-input-v3 IME channel as commitString().
+        // Some React-controlled contenteditable editors (e.g. Facebook/Lexical) apply a
+        // raw forwarded BackSpace (native key event) but don't pick up the commitString()
+        // that follows it, so the deleted character never gets replaced and just vanishes.
+        // deleteSurroundingText + commitString are both IME-channel ops the editor's own
+        // input listeners observe consistently.
+        const auto& surrounding = ic_->surroundingText();
+        if (charsToDelete > 0) {
+            if (surrounding.isValid()) {
+                ic_->deleteSurroundingText(-static_cast<int>(charsToDelete), static_cast<int>(charsToDelete));
+            } else {
+                for (size_t i = 0; i < charsToDelete; i++) {
+                    ic_->forwardKey(Key(FcitxKey_BackSpace));
+                }
+            }
         }
         if (!addedPart.empty()) {
             ic_->commitString(addedPart);

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -104,7 +104,15 @@ namespace fcitx {
         bool                    shouldCapitalize_   = false;
         bool                    isPrevPunctuation_  = false;
         int64_t                 lastDeactivateTime_ = 0;
-        bool                    wa_chromium_flag    = false;
+        /// Chromium fires FocusOut/Reset milliseconds after our own forwarded BackSpace+commit
+        /// (e.g. MS365 recreates its edit field); resets inside this window must not wipe compose state.
+        static constexpr int64_t kSelfEditResetGuardMs        = 60;
+        int64_t                  lastSelfEditTime_            = 0; ///< now_ms() of the last self-inflicted edit (forwarded BS/commit)
+        bool                     wa_chromium_flag             = false;
+        bool                     wa_chrome_forwardkey_delete_ = false; ///< Chrome: use forwardKey(BackSpace)+commitString instead of async uinput backspaces
+        int                      ackAppCached_                = -1;    ///< -1 unknown, 0 not a chromium-family app, 1 chromium-family app
+        bool                     skipSurrTextRebuild_         = false; ///< Skip surrounding-text rebuild on the next key after a forwarded BackSpace/special key
+        bool                     forwardNextKeyRaw_           = false; ///< Chromium drops the first commitString while re-binding IME after a tab switch; deliver that key raw
 
         /**
          * @brief Connects to the uinput server.
@@ -188,6 +196,22 @@ namespace fcitx {
          * @return True if key was forwarded.
          */
         bool checkForwardSpecialKey(KeyEvent& keyEvent, KeySym& currentSym);
+
+        /**
+         * @brief Performs Chrome-specific deletion via forwarded BackSpace keys then commits added text.
+         * @param keyEvent The triggering key event (accepted here).
+         * @param deletedPart Text to delete.
+         * @param addedPart Text to insert after deletion.
+         */
+        void chromeForwardDelete(KeyEvent& keyEvent, const std::string& deletedPart, const std::string& addedPart);
+
+        /**
+         * @brief Enables chromium workarounds even when keys arrive before activate().
+         *
+         * Chrome re-enables text-input only on the first keystroke after a tab/window
+         * switch, so that key can be processed before FocusIn set the workaround flags.
+         */
+        void ensureChromiumWorkarounds();
 
         /**
          * @brief Handles uinput mode processing.


### PR DESCRIPTION
## Mô tả

Sửa lỗi nhập liệu tiếng Việt trong các trình duyệt Chromium trên **Wayland** ở **chế độ Uinput**, giải quyết #190.

**Nguyên nhân gốc**: Trên Wayland, Chromium kết nối qua frontend `wayland` (`is_dbus = false`) nên toàn bộ workaround cho Chromium bị bỏ qua. Phép thay thế dấu khi đó chạy bằng backspace uinput **bất đồng bộ**, đua với `commitString` qua kênh text-input bên trong pipeline của Chromium, gây ra:

- Lặp ký tự đầu trên thanh tìm kiếm (`á` → `aá`) — đúng triệu chứng #190
- Ký tự commit sai vị trí, nuốt ký tự khi gõ trong web editor (MS365, Google Docs)
- Mất ký tự đầu / không gõ được sau khi Ctrl+Tab hoặc Alt+Tab

Các nguyên nhân trên đã được xác minh bằng log `fcitx5 --verbose 'lotus=5,key_trace=5'` trên KDE Plasma Wayland.

## Khác gì với PR #327 (đã đóng)?

PR #327 bị báo làm hỏng chế độ Uinput (Firefox/Chromium không gõ được). Nguyên nhân là bypass `InputContextReset` trong `reset()`: app nào bắn Reset ngay sau mỗi commit (MS365, và nhiều khả năng cả Firefox) sẽ bị xoá compose state giữa từ. PR này giữ bypass đó (cần cho Ctrl+Tab) nhưng thêm **guard 60ms**: Reset/FocusOut đến trong vòng 60ms sau chính thao tác sửa của bộ gõ (forwardKey BackSpace / commit) sẽ được bỏ qua — reset thật từ người dùng không bao giờ nhanh như vậy. Guard phủ cả đường commit uinput thường nên app ngoài ack-list (Firefox, VSCode…) cũng được bảo vệ. **Chế độ Uinput vẫn là đường chính** — không ép app nào sang Surrounding Text.

## Thay đổi

- **`activate()`**: bật workaround Chromium cho cả frontend `wayland` (trước chỉ `dbus`). Với ack-apps ở chế độ Uinput, phép thay thế dùng `forwardKey(BackSpace)` + `commitString` (cùng kênh, có thứ tự) thay vì backspace uinput async. `waitAck_` vẫn theo config `FixUinputWithAck`.
- **Phát hiện ack-app lazy tại phím đầu tiên** (`ensureChromiumWorkarounds`, cache per-IC): Chrome chỉ bật lại text-input ở phím đầu sau khi chuyển tab/cửa sổ, nên phím đó có thể được xử lý trước khi `activate()` kịp set cờ.
- **Guard reset 60ms** (`lastSelfEditTime_`): bỏ qua FocusOut/Reset đến ngay sau forwardKey/commit của chính bộ gõ — web editor (MS365) tạo lại ô nhập sau mỗi lần xoá, nếu tôn trọng reset đó thì compose state bị xoá đúng trước phím dấu (`duwj` → `dưj`).
- **Phím đầu sau FocusIn/Reset giao dạng raw key** (`forwardNextKeyRaw_`): Chromium nuốt `commitString` đầu tiên trong lúc renderer re-bind IME sau Ctrl+Tab; phím raw vừa hiển thị đúng vừa hoàn tất quá trình re-bind. Engine vẫn compose bình thường nên phím kế tiếp thay thế chính xác.
- **SurroundingText mode**: forward phím đầu raw sau FocusIn+Reset để Chrome resync surrounding text trước khi engine rebuild.
- **`isAutofillCertain`**: dùng byte offset nhất quán (cursor/anchor trong text-input-v3 là byte offset); extra BackSpace chỉ gửi khi autocomplete thực sự active.
- **`setMode()` chỉ clear buffer khi mode thực sự đổi** (commit riêng): `activate()` gọi `setMode()` mỗi lần FocusIn, mà web editor refocus sau mỗi lần thay thế → `clearAllBuffers()` vô điều kiện (thêm ở 2da90c7) xoá compose state giữa từ. Giữ nguyên hành vi clear khi đổi mode thật (menu, cycle shortcut) đúng ý định gốc của commit đó.

## Đã test (KDE Plasma Wayland, Arch, fcitx5 5.1.21, chế độ Uinput Smooth)

| Kịch bản | Trước | Sau |
|---|---|---|
| Thanh địa chỉ Chrome, gõ `as` | `aá` (lặp — #190) | `á` |
| Excel MS365 web, gõ `duwj asn` | `dj n` / `dưj án` | `dự án` |
| MS365, gõ `xasc nhaanj` | `xác nhânj` | `xác nhận` |
| Ctrl+Tab rồi gõ ngay `dd` | mất `d` đầu | `đ` |
| Alt+Tab rồi gõ ngay `deer` | mất ký tự đầu | `dể` |
| LibreOffice Writer/Calc | loạn vị trí, nuốt ký tự | gõ bình thường |
| VSCode (ngoài ack-list) + Ctrl+Tab | — | gõ bình thường, không regression |
| wezterm (terminal) | gõ bình thường | gõ bình thường |

Lưu ý cho reviewer: mình chưa có môi trường X11 để test lại nhánh dbus/XIM — mong bạn test giúp trên setup cũ từng làm #327 fail (Firefox + Chromium, uinput). Về lý thuyết, guard 60ms là phần còn thiếu khiến #327 break.
