### PR TITLE
fix(state): replay buffered keys on deletion completion

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -466,8 +466,7 @@ namespace fcitx {
 
             event.filterAndAccept(); // Filter out the final trigger backspace.
             is_deleting_.store(false);
-            if (getFrontendName(ic_) == "dbus" && !ic_->surroundingText().isValid())
-                replayBufferedKeys(); // Does we need drop this?
+            replayBufferedKeys();
             return true;
         }
         return false;
@@ -975,6 +974,9 @@ namespace fcitx {
             is_deleting_.store(false);
             current_backspace_count_ = 0;
             expected_backspaces_     = 0;
+            if (!buffered_keys_.empty()) {
+                replayBufferedKeys();
+            }
         }
         if (needEngineReset.load() && realMode != LotusMode::Off) {
             LOTUS_INFO("Need engine reset");


### PR DESCRIPTION
Fixes an issue where fast typing drops letters/characters on Wayland native applications (Firefox, Zen, Antigravity, Discord, Equicord, etc.).

### Root Cause
When typing fast in Vietnamese input modes, text replacement triggers backspaces via uinput (). Subsequent fast-typed keystrokes are intercepted, swallowed, and queued in . Upon uinput deletion completion,  was conditionally guarded by . On Wayland, native apps return frontend , causing the condition to evaluate to false and dropping all buffered keys.

### Fix
- Unconditionally invoke  when  is set to  in .
- Add safety  call in  when backspace threshold is met.