### PR TITLE
fix(runit): sửa lỗi không nhận đúng tên user khi dùng symlink

### DIFF
--- a/misc/fcitx5-lotus.runit
+++ b/misc/fcitx5-lotus.runit
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 svc="$(basename "$(pwd)")"
+svc=$(tr '\0' ' ' < /proc/$PPID/cmdline | awk '{print $NF}')
+svc=$(basename "$svc")
+
 user="${svc#*.}"
 if [ "$user" = "$svc" ]; then
     echo "fcitx5-lotus cannot be started directly." >&2


### PR DESCRIPTION
Lệnh basename "$(pwd)" khi chạy dưới runit sẽ bị Kernel Linux resolve ra đường dẫn vật lý (ví dụ /etc/sv/fcitx5-lotus), làm mất đuôi .<user> ở symlink. Cách này dùng /proc/$PPID/cmdline để đọc tên symlink mà runsv đã gọi, giúp bóc tách đúng tên user.