### PR TITLE
perf(settings-gui): lazy load pages and dictionary editor data

### DIFF
--- a/settings-gui/ui/main_window.py
+++ b/settings-gui/ui/main_window.py
@@ -23,13 +23,7 @@ from qtpy.QtCore import Qt, QSize
 from i18n import _
 from core.dbus_handler import LotusDBusHandler
 
-from ui.pages.dynamic_settings import DynamicSettingsPage, SettingsCategory
-from ui.pages.macro_editor import MacroEditorPage
-from ui.pages.dict_editor import DictEditorPage
-from ui.pages.keymap_editor import KeymapEditorPage
-from ui.pages.about import AboutPage
-from ui.pages.mode_manager import ModeManagerPage
-from ui.pages.backup import BackupPage
+# Lazy loading pages on demand
 
 
 class LotusSettingsWindow(QMainWindow):
@@ -48,10 +42,14 @@ class LotusSettingsWindow(QMainWindow):
 
     def update_reset_button_state(self):
         any_modified_from_default = any(
-            (hasattr(self.content_stack.widget(i), "is_modified_from_default")
-             and self.content_stack.widget(i).is_modified_from_default())
-            or (hasattr(self.content_stack.widget(i), "is_modified")
-                and self.content_stack.widget(i).is_modified())
+            (
+                hasattr(self.content_stack.widget(i), "is_modified_from_default")
+                and self.content_stack.widget(i).is_modified_from_default()
+            )
+            or (
+                hasattr(self.content_stack.widget(i), "is_modified")
+                and self.content_stack.widget(i).is_modified()
+            )
             for i in range(self.content_stack.count())
         )
         self.btn_reset.setEnabled(any_modified_from_default)
@@ -94,8 +92,7 @@ class LotusSettingsWindow(QMainWindow):
 
         self.sidebar = QListWidget()
         self.sidebar.setFixedWidth(200)
-        self.sidebar.setStyleSheet(
-            """
+        self.sidebar.setStyleSheet("""
             QListWidget {
                 border: none;
                 background: transparent;
@@ -114,8 +111,7 @@ class LotusSettingsWindow(QMainWindow):
             QListWidget::item:hover:!selected {
                 background: palette(alternate-base);
             }
-        """
-        )
+        """)
         self.sidebar.setObjectName("Sidebar")
         self.sidebar.setFrameShape(QFrame.NoFrame)
 
@@ -168,61 +164,81 @@ class LotusSettingsWindow(QMainWindow):
         layout.addWidget(container)
 
     def _setup_pages(self):
-        # Top-level Settings Pages
-        self._add_page(
-            _("General"),
-            "preferences-system",
-            DynamicSettingsPage(self.dbus_handler, category=SettingsCategory.GENERAL),
-        )
-        self._add_page(
-            _("Typing"),
-            "input-keyboard",
-            DynamicSettingsPage(self.dbus_handler, category=SettingsCategory.TYPING),
-        )
-        self._add_page(
-            _("Applications"),
-            "applications-other",
-            ModeManagerPage(self.dbus_handler),
-        )
-        self._add_page(
-            _("Macros"),
-            "accessories-text-editor",
-            MacroEditorPage(self.dbus_handler),
-        )
-        self._add_page(
-            _("Dictionary"),
-            "edit-copy",
-            DictEditorPage(self.dbus_handler),
-        )
-        self._add_page(
-            _("Keymap"),
-            "preferences-desktop-keyboard",
-            KeymapEditorPage(self.dbus_handler),
-        )
-        self._add_page(
-            _("Shortcuts"),
-            "preferences-desktop-keyboard-shortcuts",
-            DynamicSettingsPage(self.dbus_handler, category=SettingsCategory.SHORTCUTS),
-        )
-        self._add_page(
-            _("Appearance"),
-            "preferences-desktop-theme",
-            DynamicSettingsPage(
-                self.dbus_handler, category=SettingsCategory.APPEARANCE
-            ),
-        )
-        self._add_page(
-            _("Backup"),
-            "document-save-as",
-            BackupPage(self.dbus_handler),
-        )
+        def create_general():
+            from ui.pages.dynamic_settings import DynamicSettingsPage, SettingsCategory
 
-        # Bottom section
+            return DynamicSettingsPage(
+                self.dbus_handler, category=SettingsCategory.GENERAL
+            )
+
+        def create_typing():
+            from ui.pages.dynamic_settings import DynamicSettingsPage, SettingsCategory
+
+            return DynamicSettingsPage(
+                self.dbus_handler, category=SettingsCategory.TYPING
+            )
+
+        def create_applications():
+            from ui.pages.mode_manager import ModeManagerPage
+
+            return ModeManagerPage(self.dbus_handler)
+
+        def create_macros():
+            from ui.pages.macro_editor import MacroEditorPage
+
+            return MacroEditorPage(self.dbus_handler)
+
+        def create_dict():
+            from ui.pages.dict_editor import DictEditorPage
+
+            return DictEditorPage(self.dbus_handler)
+
+        def create_keymap():
+            from ui.pages.keymap_editor import KeymapEditorPage
+
+            return KeymapEditorPage(self.dbus_handler)
+
+        def create_shortcuts():
+            from ui.pages.dynamic_settings import DynamicSettingsPage, SettingsCategory
+
+            return DynamicSettingsPage(
+                self.dbus_handler, category=SettingsCategory.SHORTCUTS
+            )
+
+        def create_appearance():
+            from ui.pages.dynamic_settings import DynamicSettingsPage, SettingsCategory
+
+            return DynamicSettingsPage(
+                self.dbus_handler, category=SettingsCategory.APPEARANCE
+            )
+
+        def create_backup():
+            from ui.pages.backup import BackupPage
+
+            return BackupPage(self.dbus_handler)
+
+        def create_about():
+            from ui.pages.about import AboutPage
+
+            return AboutPage()
+
+        self._add_page(_("General"), "preferences-system", create_general)
+        self._add_page(_("Typing"), "input-keyboard", create_typing)
+        self._add_page(_("Applications"), "applications-other", create_applications)
+        self._add_page(_("Macros"), "accessories-text-editor", create_macros)
+        self._add_page(_("Dictionary"), "edit-copy", create_dict)
+        self._add_page(_("Keymap"), "preferences-desktop-keyboard", create_keymap)
+        self._add_page(
+            _("Shortcuts"), "preferences-desktop-keyboard-shortcuts", create_shortcuts
+        )
+        self._add_page(_("Appearance"), "preferences-desktop-theme", create_appearance)
+        self._add_page(_("Backup"), "document-save-as", create_backup)
+
         spacer = QListWidgetItem()
         spacer.setFlags(Qt.NoItemFlags)
         spacer.setSizeHint(QSize(0, 20))
         self.sidebar.addItem(spacer)
-        self._add_page(_("About"), "help-about", AboutPage())
+        self._add_page(_("About"), "help-about", create_about)
 
     def on_restore_defaults(self):
         """Resets all settings to their default values."""
@@ -296,9 +312,7 @@ class LotusSettingsWindow(QMainWindow):
         if not quiet:
             from qtpy.QtWidgets import QMessageBox
 
-            QMessageBox.information(
-                self, _("Success"), _("Settings saved.")
-            )
+            QMessageBox.information(self, _("Success"), _("Settings saved."))
         return True
 
     def on_ok(self):
@@ -326,7 +340,13 @@ class LotusSettingsWindow(QMainWindow):
 
         role = item.data(Qt.UserRole)
         if role == "page":
-            widget = item.data(Qt.UserRole + 1)
+            widget = item.data(Qt.UserRole + 2)
+            if widget is None:
+                factory = item.data(Qt.UserRole + 1)
+                if factory:
+                    widget = factory()
+                    self.content_stack.addWidget(widget)
+                    item.setData(Qt.UserRole + 2, widget)
             if widget:
                 self.content_stack.setCurrentWidget(widget)
             self.update_reset_button_state()
@@ -343,11 +363,10 @@ class LotusSettingsWindow(QMainWindow):
         self.resize(w, h)
         self.move((screen.width() - w) // 2, (screen.height() - h) // 2)
 
-    def _add_page(self, title: str, icon_name: str, widget: QWidget):
+    def _add_page(self, title: str, icon_name: str, page_factory):
         item = QListWidgetItem(QIcon.fromTheme(icon_name), title)
         item.setData(Qt.UserRole, "page")
-
-        self.content_stack.addWidget(widget)
-        item.setData(Qt.UserRole + 1, widget)
+        item.setData(Qt.UserRole + 1, page_factory)
+        item.setData(Qt.UserRole + 2, None)
 
         self.sidebar.addItem(item)

--- a/settings-gui/ui/pages/dict_editor.py
+++ b/settings-gui/ui/pages/dict_editor.py
@@ -41,11 +41,13 @@ class DictEditorPage(BaseEditorPage):
         self.dbus = dbus_handler
         self.words = []  # List of all words
         self.initial_state = {}
+        self._is_loaded = False
         self._setup_ui()
-        self.load_data()
 
     def _get_local_dict_path(self) -> str:
-        xdg_data_home = os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
+        xdg_data_home = os.environ.get(
+            "XDG_DATA_HOME", os.path.expanduser("~/.local/share")
+        )
         return os.path.join(xdg_data_home, "fcitx5/lotus/vietnamese.cm.dict")
 
     def _get_global_dict_path(self) -> str:
@@ -67,8 +69,12 @@ class DictEditorPage(BaseEditorPage):
         title = QLabel(_("Custom Dictionary"))
         title.setObjectName("CategoryTitle")
         main_layout.addWidget(title)
-        
-        explanation = QLabel(_("Words in the custom dictionary will be excluded from 'Auto Restore Invalid Words'. Use this for names, technical terms, or words not yet in the built-in dictionary."))
+
+        explanation = QLabel(
+            _(
+                "Words in the custom dictionary will be excluded from 'Auto Restore Invalid Words'. Use this for names, technical terms, or words not yet in the built-in dictionary."
+            )
+        )
         explanation.setWordWrap(True)
         explanation.setStyleSheet("color: gray; font-size: 13px;")
         main_layout.addWidget(explanation)
@@ -140,6 +146,12 @@ class DictEditorPage(BaseEditorPage):
         content_layout.addLayout(toolbar_layout)
         self.update_button_states()
 
+    def showEvent(self, event):
+        super().showEvent(event)
+        if not self._is_loaded:
+            self.load_data()
+            self._is_loaded = True
+
     def load_data(self):
         self.blockSignals(True)
         try:
@@ -155,7 +167,7 @@ class DictEditorPage(BaseEditorPage):
             local_path = self._get_local_dict_path()
             global_path = self._get_global_dict_path()
             path_to_read = local_path if os.path.exists(local_path) else global_path
-            
+
             if os.path.exists(path_to_read):
                 try:
                     with open(path_to_read, "r", encoding="utf-8") as f:
@@ -176,18 +188,18 @@ class DictEditorPage(BaseEditorPage):
     def _rebuild_table(self, filtered_words: list = None):
         """Rebuilds the table based on self.words or filtered_words."""
         display_words = filtered_words if filtered_words is not None else self.words
-        
+
         num_cols = 3
         num_rows = (len(display_words) + num_cols - 1) // num_cols
         self.table.setRowCount(num_rows)
-        
+
         for i, word in enumerate(display_words):
             row = i // num_cols
             col = i % num_cols
             item = QTableWidgetItem(word)
             self.table.setItem(row, col, item)
             self._apply_cell_highlight(item, word)
-            
+
         # Clear remaining cells in the last row
         for i in range(len(display_words), num_rows * num_cols):
             row = i // num_cols
@@ -225,7 +237,9 @@ class DictEditorPage(BaseEditorPage):
         config_data = self.dbus.get_config()
         if config_data:
             values = config_data.get("values", {})
-            values["EnableDictionary"] = "True" if self.cb_enable.isChecked() else "False"
+            values["EnableDictionary"] = (
+                "True" if self.cb_enable.isChecked() else "False"
+            )
             self.dbus.set_config(values)
 
         local_path = self._get_local_dict_path()
@@ -234,7 +248,7 @@ class DictEditorPage(BaseEditorPage):
             with open(local_path, "w", encoding="utf-8") as f:
                 for word in self.words:
                     f.write(f"{word}\n")
-            
+
             # Trigger engine reload by setting global config (unchanged)
             if self.dbus.iface:
                 current_config = self.dbus.get_config()
@@ -243,7 +257,9 @@ class DictEditorPage(BaseEditorPage):
 
             self.initial_state = self._get_current_state()
         except Exception as e:
-            QMessageBox.warning(self, _("Error"), _("Failed to save dictionary: {}").format(e))
+            QMessageBox.warning(
+                self, _("Error"), _("Failed to save dictionary: {}").format(e)
+            )
 
     def upsert_row(self, word: str, sort: bool = True):
         if word in self.words:
@@ -299,10 +315,12 @@ class DictEditorPage(BaseEditorPage):
         """Handles validation and Add button state."""
         word = self.input_word.text().strip()
         is_invalid = self._is_invalid_word(word)
-        
+
         if is_invalid:
             self.input_word.setStyleSheet("color: red;")
-            self.input_word.setToolTip(_("Warning: Dictionary words should not contain spaces."))
+            self.input_word.setToolTip(
+                _("Warning: Dictionary words should not contain spaces.")
+            )
         else:
             self.input_word.setStyleSheet("")
             self.input_word.setToolTip("")


### PR DESCRIPTION
## Mô tả
Pull Request này tối ưu hóa thời gian khởi động của settings-gui bằng cách áp dụng cơ chế lazy loading cho các trang cấu hình và trì hoãn việc nạp dữ liệu cho trình chỉnh sửa từ điển.

## Các thay đổi chính
- ui/pages/dict_editor.py: Trì hoãn việc nạp dữ liệu từ điển sang sự kiện showEvent, giúp loại bỏ hoàn toàn các thao tác I/O - đọc file trong quá trình ứng dụng khởi động.

- ui/main_window.py: Chuyển các tab cài đặt sang cơ chế tạo và import lười (lazy creation/import) thông qua factory function. Trang chỉ được khởi tạo khi người dùng thực sự bấm chuyển sang tab đó.

## Kết quả đo hiệu năng (cProfile)
Thử nghiệm trên phần cứng cấu hình thấp (Intel Celeron N2840):

- Trước khi tối ưu: ~5.5 giây khởi động (~734k function calls)
- Sau khi tối ưu: ~2.9 giây khởi động (~504k function calls)
- Cải thiện: Giảm ~47% thời gian khởi động ban đầu và loại bỏ khoảng ~230k lời gọi hàm không cần thiết.