### PR TITLE
fix(uinput): prevent FD leak on failed reconnect during key input

### DIFF
--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -103,6 +103,7 @@ namespace fcitx {
             return true;
         }
         LOTUS_ERROR("Failed to connect to socket: " + std::string(strerror(errno)));
+        close(current_fd);
         int old_fd = uinput_client_fd_.exchange(-1);
         if (old_fd != -1) {
             close(old_fd);


### PR DESCRIPTION
Fix a socket file descriptor leak when reconnecting to the uinput server fails.

connect_uinput_server() creates a new socket FD before calling connect(). When the connection fails, the function returns false without closing the newly created current_fd.

Since keyEvent() retries the connection while the uinput client is disconnected, repeated key input can create additional leaked socket FDs