### PR TITLE
fix(server): authenticate mouse socket clients

### DIFF
--- a/server/lotus-server.cpp
+++ b/server/lotus-server.cpp
@@ -343,8 +343,39 @@ int main(int argc, char* argv[]) {
         if ((fds[2].revents & POLLIN) != 0) {
             int new_fd = accept4(mouse_server_fd.get(), nullptr, nullptr, SOCK_NONBLOCK);
             if (new_fd >= 0) {
-                LotusLogger::instance().info("New mouse flag client connected");
-                addon_fd.reset(new_fd);
+                struct ucred cred{};
+                socklen_t    len                = sizeof(struct ucred);
+                char         exe_path[PATH_MAX] = {0};
+
+                bool         authorized = false;
+                if (getsockopt(new_fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) == 0) {
+                    if (cred.uid == expected_uid) {
+                        char path[64];
+                        snprintf(path, sizeof(path), "/proc/%d/exe", cred.pid);
+
+                        ssize_t ret = readlink(path, exe_path, sizeof(exe_path) - 1);
+                        if (ret != -1) {
+                            exe_path[ret] = '\0'; // NOLINT
+                        }
+
+                        if (strcmp(exe_path, "/usr/bin/fcitx5") == 0) {
+                            authorized = true;
+                        } else {
+                            LotusLogger::instance().warn("Unauthorized executable connection attempt to mouse socket from: " + std::string(exe_path));
+                        }
+                    } else {
+                        LotusLogger::instance().warn("Unauthorized UID connection attempt to mouse socket from UID: " + std::to_string(cred.uid));
+                    }
+                } else {
+                    LotusLogger::instance().warn("Failed to get peer credentials for mouse socket");
+                }
+
+                if (authorized) {
+                    LotusLogger::instance().info("New mouse flag client connected");
+                    addon_fd.reset(new_fd);
+                } else {
+                    close(new_fd);
+                }
             }
         }
 


### PR DESCRIPTION
## Vấn đề

Socket bàn phím hiện đã kiểm tra client bằng `SO_PEERCRED`, UID và `/proc/<pid>/exe`.

Nhưng socket chuột thì chưa có bước này. Client local nào kết nối được cũng sẽ thay thế `addon_fd` hiện tại.

Điều này có thể làm connection hợp lệ của fcitx5 bị chiếm bởi một process khác.

## Thay đổi

Thêm kiểm tra cho client kết nối vào mouse socket:

- kiểm tra peer bằng `SO_PEERCRED`
- UID phải đúng với user đang chạy fcitx5
- `/proc/<pid>/exe` phải là `/usr/bin/fcitx5`
- chỉ thay `addon_fd` sau khi xác thực thành công
- connection không hợp lệ sẽ bị đóng và không ảnh hưởng connection hiện tại

Logic xác thực giữ giống với keyboard socket đang có.

## Kiểm tra

- đã chạy `clang-format`
- `git diff --check` pass
- local chưa build được do thiếu `Fcitx5Core` development files
- `ctest` hiện không có test nào được cấu hình