### PR TITLE
fix: guard empty newText in getLastRune check

### DIFF
--- a/bamboo/fcitxbambooengine.go
+++ b/bamboo/fcitxbambooengine.go
@@ -307,7 +307,7 @@ func (e *FcitxBambooEngine) getCommitText(keyVal, state uint32, oldText string) 
 					e.preeditor.ProcessKey(' ', bamboo.EnglishMode)
 				}
 				return ret, isWordBreakRune
-			} else if getLastRune(newText) == keyRune {
+			} else if len(newText) > 0 && getLastRune(newText) == keyRune {
 				// f] => f]
 				var isWordBreakRune = bamboo.IsWordBreakSymbol(keyRune)
 				if isWordBreakRune {


### PR DESCRIPTION
## Summary
- Fix: Re-add `len(newText) > 0` check before  `getLastRune(newText) == keyRune`.