### PR TITLE
fix: transform bracket when capslock on

### DIFF
--- a/bamboo/fcitxbambooengine.go
+++ b/bamboo/fcitxbambooengine.go
@@ -231,19 +231,19 @@ func inKeyList(list []rune, key rune) bool {
 func (e *FcitxBambooEngine) toUpper(keyRune rune) rune {
 	switch keyRune {
 	case '[':
-		if inKeyList(e.preeditor.GetInputMethod().AppendingKeys, keyRune) {
+		if e.preeditor.CanProcessKey(keyRune) {
 			return '{'
 		}
 	case ']':
-		if inKeyList(e.preeditor.GetInputMethod().AppendingKeys, keyRune) {
+		if e.preeditor.CanProcessKey(keyRune) {
 			return '}'
 		}
 	case '{':
-		if inKeyList(e.preeditor.GetInputMethod().AppendingKeys, keyRune) {
+		if e.preeditor.CanProcessKey(keyRune) {
 			return '['
 		}
 	case '}':
-		if inKeyList(e.preeditor.GetInputMethod().AppendingKeys, keyRune) {
+		if e.preeditor.CanProcessKey(keyRune) {
 			return ']'
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes an issue where bracket keys (`[` / `]`) fail to transform into uppercase Vietnamese vowels (`Ơ` / `Ư`) when **Caps Lock** is enabled. (#383)

Close #383