### PR TITLE
fix(SPEC): Remove %clean

### DIFF
--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -128,10 +128,6 @@ Vietnamese input method for fcitx5
 
 %{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
-%clean
-rm -rf %{buildroot}
-rm -rf %{_builddir}/%{name}-%{version}
-
 %post
 %systemd_post fcitx5-lotus-server@.service
 if [ -x /usr/bin/udevadm ]; then

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -129,10 +129,6 @@ Vietnamese input method for fcitx5
 
 %{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
-%clean
-rm -rf %{buildroot}
-rm -rf %{_builddir}/%{name}-%{version}
-
 %pre
 %sysusers_create_package lotus %{_prefix}/lib/sysusers.d/lotus.conf
 


### PR DESCRIPTION
PR này xoá khối %clean khỏi file SPEC của Fedora và OpenSUSE, fix cho issue #400