### PR TITLE
fix: avoid authen mouse socket when click

### DIFF
--- a/src/lotus-monitor.cpp
+++ b/src/lotus-monitor.cpp
@@ -21,6 +21,38 @@
 
 std::thread mouse_thread = std::thread();
 
+static bool authenticateMouseSocketPeer(int sock, std::string& out_exe_path) {
+    struct ucred cred{};
+    socklen_t    cred_len = sizeof(cred);
+
+    if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &cred, &cred_len) != 0) {
+        LOTUS_ERROR("Failed to get peer credentials: " + std::string(strerror(errno)));
+        return false;
+    }
+
+    char proc_path[64];
+    snprintf(proc_path, sizeof(proc_path), "/proc/%d/cmdline", cred.pid);
+
+    int fd = open(proc_path, O_RDONLY);
+    if (fd < 0) {
+        LOTUS_ERROR("Failed to open cmdline: " + std::string(strerror(errno)));
+        return false;
+    }
+
+    char exe_path[PATH_MAX] = {0};
+    ssize_t bytes_read = read(fd, exe_path, sizeof(exe_path) - 1);
+    close(fd);
+
+    if (bytes_read <= 0) {
+        LOTUS_ERROR("Failed to read cmdline: " + std::string(strerror(errno)));
+        return false;
+    }
+
+    out_exe_path = exe_path;
+
+    return strcmp(exe_path, "/usr/bin/fcitx5-lotus-server") == 0;
+}
+
 void        mousePressResetThread() {
     const std::string mouse_socket_path = buildSocketPath("mouse_socket");
     LOTUS_INFO("Mouse press reset thread started.");
@@ -46,6 +78,15 @@ void        mousePressResetThread() {
             continue;
         }
         LOTUS_INFO("Mouse socket connected.");
+
+        std::string peer_exe_path;
+        if (!authenticateMouseSocketPeer(sock, peer_exe_path)) {
+            LOTUS_WARN("Unauthorized connection attempt from: " + peer_exe_path);
+            close(sock);
+            sleep(1);
+            continue;
+        }
+        
         mouse_socket_fd.store(sock, std::memory_order_release);
 
         struct pollfd pfd{};
@@ -64,35 +105,22 @@ void        mousePressResetThread() {
                     break;
                 }
 
-                struct ucred cred{};
-                socklen_t    len                = sizeof(struct ucred);
-                char         exe_path[PATH_MAX] = {0};
-                if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &cred, &len) == 0) {
-                    char path[64];
-                    snprintf(path, sizeof(path), "/proc/%d/cmdline", cred.pid);
-                    int fd = open(path, O_RDONLY);
-                    if (fd >= 0) {
-                        if (read(fd, exe_path, sizeof(exe_path) - 1) < 0) {
-                            LOTUS_ERROR("Failed to read cmdline: " + std::string(strerror(errno)));
-                        }
-                        close(fd);
-                    }
-                }
-
-                if (strcmp(exe_path, "/usr/bin/fcitx5-lotus-server") == 0) {
+                if (n >= 1 && buf[0] == 'C') {
                     LOTUS_DEBUG("Mouse click detected from server. Resetting engine.");
                     needEngineReset.store(true, std::memory_order_release);
                     g_mouse_clicked.store(true, std::memory_order_release);
-                } else {
-                    LOTUS_WARN("Unauthorized connection attempt from: " + std::string(exe_path));
                 }
+                else {
+                    LOTUS_WARN("Unexpected message received from mouse socket: " + std::string(buf, n));
+                }
+
             } else if (ret < 0 && errno != EINTR) {
                 LOTUS_ERROR("Mouse socket poll error: " + std::string(strerror(errno)));
                 break;
             }
         }
-        close(sock);
         mouse_socket_fd.store(-1, std::memory_order_release);
+        close(sock);
     }
 }
 


### PR DESCRIPTION
## Summary
-  Moves peer credential verification out of the mouse event loop avoid unnecessary I/O overhead on every mouse click.