### PR TITLE
OpenSUSE readme

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -69,7 +69,7 @@ If you want to compile the input method from source to contribute or customize:
 
 - **Debian/Ubuntu:** `sudo apt-get install cmake extra-cmake-modules libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev libinput-dev libudev-dev g++ golang hicolor-icon-theme pkg-config libx11-dev fcitx5-modules-dev python3-qtpy python3-dbus acl librsvg2-bin`
 - **Fedora/RHEL:** `sudo dnf install cmake extra-cmake-modules fcitx5-devel libinput-devel libudev-devel gcc-c++ golang hicolor-icon-theme systemd-devel libX11-devel python3-pyside6 python3-QtPy python3-dbus acl librsvg2-tools`
-- **openSUSE:** `sudo zypper install cmake kf6-extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel udev python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
+- **openSUSE:** `sudo zypper install cmake kf6-extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
 - **Arch:** `sudo pacman -S --needed cmake extra-cmake-modules gcc go git libx11 python make pkgconf acl fcitx5 libinput hicolor-icon-theme python-qtpy python-dbus librsvg`
 
 ### Install

--- a/README.en.md
+++ b/README.en.md
@@ -69,7 +69,7 @@ If you want to compile the input method from source to contribute or customize:
 
 - **Debian/Ubuntu:** `sudo apt-get install cmake extra-cmake-modules libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev libinput-dev libudev-dev g++ golang hicolor-icon-theme pkg-config libx11-dev fcitx5-modules-dev python3-qtpy python3-dbus acl librsvg2-bin`
 - **Fedora/RHEL:** `sudo dnf install cmake extra-cmake-modules fcitx5-devel libinput-devel libudev-devel gcc-c++ golang hicolor-icon-theme systemd-devel libX11-devel python3-pyside6 python3-QtPy python3-dbus acl librsvg2-tools`
-- **openSUSE:** `sudo zypper install cmake extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel udev python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
+- **openSUSE:** `sudo zypper install cmake kf6-extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel udev python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
 - **Arch:** `sudo pacman -S --needed cmake extra-cmake-modules gcc go git libx11 python make pkgconf acl fcitx5 libinput hicolor-icon-theme python-qtpy python-dbus librsvg`
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Nếu bạn muốn tự biên dịch bộ gõ từ mã nguồn để đóng góp
 
 - **Debian/Ubuntu:** `sudo apt-get install cmake extra-cmake-modules libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev libinput-dev libudev-dev g++ golang hicolor-icon-theme pkg-config libx11-dev fcitx5-modules-dev python3-qtpy python3-dbus acl librsvg2-bin`
 - **Fedora/RHEL:** `sudo dnf install cmake extra-cmake-modules fcitx5-devel libinput-devel libudev-devel gcc-c++ golang hicolor-icon-theme systemd-devel libX11-devel python3-pyside6 python3-QtPy python3-dbus acl librsvg2-tools`
-- **openSUSE:** `sudo zypper install cmake extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel udev python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
+- **openSUSE:** `sudo zypper install cmake kf6-extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel udev python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
 - **Arch:** `sudo pacman -S --needed cmake extra-cmake-modules gcc go git libx11 python make pkgconf acl fcitx5 libinput hicolor-icon-theme python-qtpy python-dbus librsvg`
 
 ### Cài đặt

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Nếu bạn muốn tự biên dịch bộ gõ từ mã nguồn để đóng góp
 
 - **Debian/Ubuntu:** `sudo apt-get install cmake extra-cmake-modules libfcitx5core-dev libfcitx5config-dev libfcitx5utils-dev libinput-dev libudev-dev g++ golang hicolor-icon-theme pkg-config libx11-dev fcitx5-modules-dev python3-qtpy python3-dbus acl librsvg2-bin`
 - **Fedora/RHEL:** `sudo dnf install cmake extra-cmake-modules fcitx5-devel libinput-devel libudev-devel gcc-c++ golang hicolor-icon-theme systemd-devel libX11-devel python3-pyside6 python3-QtPy python3-dbus acl librsvg2-tools`
-- **openSUSE:** `sudo zypper install cmake kf6-extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel udev python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
+- **openSUSE:** `sudo zypper install cmake kf6-extra-cmake-modules fcitx5-devel libinput-devel systemd-devel gcc-c++ go hicolor-icon-theme systemd-devel libX11-devel python3-pyside6 python3-QtPy python3-dbus-python acl rsvg-convert`
 - **Arch:** `sudo pacman -S --needed cmake extra-cmake-modules gcc go git libx11 python make pkgconf acl fcitx5 libinput hicolor-icon-theme python-qtpy python-dbus librsvg`
 
 ### Cài đặt


### PR DESCRIPTION
# Mô tả
Cập nhật build-depends cho OpenSUSE ở file README từ extra-cmake-modules thành kf6-extra-cmake-modules và xoá udev thừa ra

## Loại thay đổi

- [ ] Tính năng mới
- [ ] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [x] Cập nhật tài liệu
- [ ] Cải tiến CI/CD

## Liên kết issue

## Screenshot (cho UI changes)

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ ] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [ ] Build C++ thành công (`cmake .. && make`)
- [ ] Test pass (`cd bamboo/ && go test -race ./...`)
- [ ] Đã rebase với nhánh `dev` mới nhất
- [x] Các CI checks pass:
