### PR TITLE
Update fcitx5-lotus-server@.service.in

### DIFF
--- a/misc/fcitx5-lotus-server@.service.in
+++ b/misc/fcitx5-lotus-server@.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Fcitx5 Lotus Server for %i
-After=multi-user.target dev-uinput.device
-Requires=dev-uinput.device
+After=systemd-modules-load.service systemd-udevd.service
+Wants=systemd-modules-load.service
 
 [Service]
 User=@LOTUS_UINPUT_PROXY_USER@

--- a/misc/fcitx5-lotus-server@.service.in
+++ b/misc/fcitx5-lotus-server@.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Fcitx5 Lotus Server for %i
-After=multi-user.target udev.target
+After=multi-user.target dev-uinput.device
+Requires=dev-uinput.device
 
 [Service]
 User=@LOTUS_UINPUT_PROXY_USER@
@@ -15,7 +16,7 @@ ExecStartPre=+/usr/bin/setfacl -m u:@LOTUS_UINPUT_PROXY_USER@:rw /dev/uinput
 ExecStart=/usr/bin/fcitx5-lotus-server -u %i
 
 Restart=on-failure
-RestartSec=0
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Mô tả
PR này chuyển từ việc đợi udev sang đợi trực tiếp thiết bị Uinput ( [.device](https://www.freedesktop.org/software/systemd/man/latest/systemd.device.html) ), tăng thời gian delay trước khi khởi động lại dịch vụ, thêm các tính năng bảo mật , tài liệu của tất cả tính năng bảo mật được thêm vào:
 [ProtectSystem](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#ProtectSystem=) , [ProtectHome](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#ProtectHome=), [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#PrivateTmp=), [ProtectControlGroups](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#ProtectControlGroups=), [ProtectKernelTunables](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#ProtectKernelTunables=), [ProtectKernelModules](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#ProtectKernelModules=), [NoNewPrivileges](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#NoNewPrivileges=), [RestrictRealtime](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#RestrictRealtime=), [RestrictSUIDSGID](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#RestrictSUIDSGID=), [PrivateNetwork](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#PrivateNetwork=), [RestrictAddressFamilies](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#RestrictAddressFamilies=), [DevicePolicy](https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html#DevicePolicy=auto%7Cclosed%7Cstrict), [DeviceAllow](https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html#DeviceAllow=), [SystemCallFilter](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#SystemCallFilter=), [SystemCallArchitectures](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html?__goaway_challenge=meta-refresh&__goaway_id=f30a6df6b606cb9781aa3d5981902831&__goaway_referer=https%3A%2F%2Fwww.google.com%2F#SystemCallArchitectures=)

lưu ý rằng mình chưa chắc nó có hoạt động đúng không (mình không dùng systemd), nên cần phải kiểm tra trước khi được merge

## Loại thay đổi

- [ ] Tính năng mới
- [ ] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD
- [x] Cải tiến dịch vụ init
## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ ] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [ ] Build C++ thành công (`cmake .. && make`)
- [ ] Test pass (`cd bamboo/ && go test -race ./...`)
- [ ] Đã rebase với nhánh `dev` mới nhất
- [x] Các CI checks pass:
