### PR TITLE
Update RPM/DEB

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -21,5 +21,5 @@ Standards-Version: 4.6.0
 
 Package: fcitx5-lotus
 Architecture: any
-Depends: acl, fcitx5, fcitx5-data, udev, hicolor-icon-theme, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${misc:Depends}, ${shlibs:Depends}
+Depends: acl, fcitx5, fcitx5-data, udev, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${misc:Depends}, ${shlibs:Depends}
 Description: Vietnamese input method for fcitx5

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,6 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Nguyen Hoang Ky <nhktmdzhg@gmail.com>
 Build-Depends: debhelper-compat (= 13),
+               dh-python,
                cmake,
                g++,
                golang,
@@ -21,5 +22,5 @@ Standards-Version: 4.6.0
 
 Package: fcitx5-lotus
 Architecture: any
-Depends: acl, fcitx5, fcitx5-data, udev, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${misc:Depends}, ${shlibs:Depends}
+Depends: acl, fcitx5, fcitx5-data, udev, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${python3:Depends}, ${misc:Depends}, ${shlibs:Depends}
 Description: Vietnamese input method for fcitx5

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -22,5 +22,5 @@ Standards-Version: 4.6.0
 
 Package: fcitx5-lotus
 Architecture: any
-Depends: acl, fcitx5, fcitx5-data, udev, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${python3:Depends}, ${misc:Depends}, ${shlibs:Depends}
+Depends: acl, fcitx5, fcitx5-data, udev, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${misc:Depends}, ${shlibs:Depends}
 Description: Vietnamese input method for fcitx5

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -14,3 +14,6 @@ execute_after_dh_auto_install:
 
 override_dh_dwz:
 	@echo "Skipping dh_dwz (incompatible with Go/mixed debug sections)"
+
+override_dh_auto_configure:
+	dh_auto_configure -- -DLOTUS_BYTECOMPILE_PYTHON=OFF

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --buildsystem=cmake

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -5,11 +5,8 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 %:
 	dh $@ --buildsystem=cmake
 
-execute_after_dh_auto_install:
-	@echo "Rewriting Python shebangs..."
-	find debian/fcitx5-lotus/usr -type f \
-		-exec grep -Il '^#!.*python' {} \; 2>/dev/null | \
-		xargs -r sed -i '1s|^#!.*python.*|#!/usr/bin/python3|'
+override_dh_python3:
+	dh_python3 --shebang=/usr/bin/python3
 
 override_dh_dwz:
 	@echo "Skipping dh_dwz (incompatible with Go/mixed debug sections)"

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --buildsystem=cmake

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -28,7 +28,6 @@ Requires:       python3-QtPy
 Requires:       (python3-pyqt6 or python3-pyside6)
 Requires:       python3-dbus
 Requires:       acl
-%set_build_env export PYTHONDONTWRITEBYTECODE=1
 
 %description
 Vietnamese input method for fcitx5
@@ -38,10 +37,12 @@ Vietnamese input method for fcitx5
 find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
+export PYTHONDONTWRITEBYTECODE=1
 %cmake
 %cmake_build
 
 %install
+export PYTHONDONTWRITEBYTECODE=1
 %cmake_install
 %find_lang %{name}
 

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -20,6 +20,8 @@ BuildRequires:  libX11-devel
 BuildRequires:  golang
 BuildRequires:  python3
 BuildRequires:  librsvg2-tools
+BuildRequires:  hicolor-icon-theme
+BuildRequires:  breeze-icon-theme
 
 %{?systemd_requires}
 Requires:       fcitx5-data
@@ -48,6 +50,8 @@ Vietnamese input method for fcitx5
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt
 %{_datadir}/licenses/%{name}/LGPL-2.1-or-later.txt
 
+%dir %{_datadir}/licenses/%{name}
+%dir %{_modulesloaddir}
 %{_bindir}/fcitx5-lotus-server
 %{_bindir}/fcitx5-lotus-settings
 

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -28,6 +28,7 @@ Requires:       python3-QtPy
 Requires:       (python3-pyqt6 or python3-pyside6)
 Requires:       python3-dbus
 Requires:       acl
+%set_build_env export PYTHONDONTWRITEBYTECODE=1
 
 %description
 Vietnamese input method for fcitx5
@@ -43,7 +44,6 @@ find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3
 %install
 %cmake_install
 %find_lang %{name}
-find %{buildroot} -type d -name __pycache__ -exec rm -rf {} +
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -27,7 +27,6 @@ Requires:       fcitx5
 Requires:       python3-QtPy
 Requires:       (python3-pyqt6 or python3-pyside6)
 Requires:       python3-dbus
-Requires:       hicolor-icon-theme
 Requires:       acl
 
 %description

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -74,11 +74,13 @@ Vietnamese input method for fcitx5
 
 %dir %{_datadir}/icons/breeze
 %dir %{_datadir}/icons/breeze/status
+%dir %{_datadir}/icons/breeze/status/22
 %dir %{_datadir}/icons/breeze/status/24
 %{_datadir}/icons/breeze/status/*/fcitx-lotus*.svg
 
 %dir %{_datadir}/icons/breeze-dark
 %dir %{_datadir}/icons/breeze-dark/status
+%dir %{_datadir}/icons/breeze-dark/status/22
 %dir %{_datadir}/icons/breeze-dark/status/24
 %{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
 

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -35,7 +35,7 @@ Vietnamese input method for fcitx5
 
 %prep
 %setup -q
-%py3_shebang_fix %{buildroot}%{_datadir}/fcitx5-lotus/settings-gui/*.py
+find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
 %cmake

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -37,12 +37,10 @@ Vietnamese input method for fcitx5
 find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
-export PYTHONDONTWRITEBYTECODE=1
-%cmake
+%cmake -DLOTUS_BYTECOMPILE_PYTHON=OFF
 %cmake_build
 
 %install
-export PYTHONDONTWRITEBYTECODE=1
 %cmake_install
 %find_lang %{name}
 

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -66,6 +66,7 @@ Vietnamese input method for fcitx5
 %{_datadir}/fcitx5/lotus/
 %{_datadir}/fcitx5-lotus/
 %{_datadir}/applications/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop
+%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
 %{_datadir}/icons/hicolor/scalable/apps/*fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/scalable/status/fcitx-lotus*.svg
@@ -80,8 +81,6 @@ Vietnamese input method for fcitx5
 %dir %{_datadir}/icons/breeze-dark/status
 %dir %{_datadir}/icons/breeze-dark/status/24
 %{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
-
-%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
 %post
 %systemd_post fcitx5-lotus-server@.service

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -10,10 +10,8 @@ BuildRequires:  cmake
 BuildRequires:  extra-cmake-modules
 BuildRequires:  gcc-c++
 BuildRequires:  gettext-devel
-BuildRequires:  glibc-devel
 BuildRequires:  cmake(Fcitx5Core)
 BuildRequires:  libinput-devel
-BuildRequires:  systemd-rpm-macros
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  libX11-devel
 
@@ -21,8 +19,7 @@ BuildRequires:  golang
 BuildRequires:  python3
 BuildRequires:  librsvg2-tools
 
-%{?systemd_requires}
-Requires:       fcitx5-data
+%{?systemd_ordering}
 Requires:       fcitx5
 Requires:       python3-QtPy
 Requires:       (python3-pyqt6 or python3-pyside6)
@@ -34,7 +31,6 @@ Vietnamese input method for fcitx5
 
 %prep
 %setup -q
-find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
 %cmake -DLOTUS_BYTECOMPILE_PYTHON=OFF
@@ -43,6 +39,8 @@ find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3
 %install
 %cmake_install
 %find_lang %{name}
+%py_byte_compile %{__python3} %{buildroot}%{_datadir}/fcitx5-lotus
+
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -20,8 +20,6 @@ BuildRequires:  libX11-devel
 BuildRequires:  golang
 BuildRequires:  python3
 BuildRequires:  librsvg2-tools
-BuildRequires:  hicolor-icon-theme
-BuildRequires:  breeze-icon-theme
 
 %{?systemd_requires}
 Requires:       fcitx5-data
@@ -72,7 +70,15 @@ Vietnamese input method for fcitx5
 %{_datadir}/icons/hicolor/scalable/apps/*fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/scalable/status/fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/*/status/fcitx-lotus*.png
+
+%dir %{_datadir}/icons/breeze
+%dir %{_datadir}/icons/breeze/status
+%dir %{_datadir}/icons/breeze/status/24
 %{_datadir}/icons/breeze/status/*/fcitx-lotus*.svg
+
+%dir %{_datadir}/icons/breeze-dark
+%dir %{_datadir}/icons/breeze-dark/status
+%dir %{_datadir}/icons/breeze-dark/status/24
 %{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
 
 %{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -16,7 +16,7 @@ BuildRequires:  pkgconfig(libudev)
 BuildRequires:  libX11-devel
 
 BuildRequires:  golang
-BuildRequires:  python3
+BuildRequires:  python3-devel
 BuildRequires:  librsvg2-tools
 
 %{?systemd_ordering}

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -35,6 +35,7 @@ Vietnamese input method for fcitx5
 
 %prep
 %setup -q
+%py3_shebang_fix %{buildroot}%{_datadir}/fcitx5-lotus/settings-gui/*.py
 
 %build
 %cmake
@@ -43,6 +44,7 @@ Vietnamese input method for fcitx5
 %install
 %cmake_install
 %find_lang %{name}
+find %{buildroot} -type d -name __pycache__ -exec rm -rf {} +
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -21,6 +21,8 @@ BuildRequires:  python-rpm-macros
 BuildRequires:  sysuser-tools
 Requires(pre):  sysuser-shadow >= 3.1
 BuildRequires:  rsvg-convert
+BuildRequires:  hicolor-icon-theme
+BuildRequires:  breeze-icon-theme
 
 %{?systemd_requires}
 Requires:       fcitx5
@@ -50,6 +52,8 @@ cd %{_builddir}/%{name}-%{version}
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt
 %{_datadir}/licenses/%{name}/LGPL-2.1-or-later.txt
 
+%dir %{_datadir}/licenses/%{name}
+%dir %{_modulesloaddir}
 %{_bindir}/fcitx5-lotus-server
 %{_bindir}/fcitx5-lotus-settings
 

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -27,7 +27,6 @@ Requires:       fcitx5
 Requires:       python3-QtPy
 Requires:       (python3-PyQt6 or python3-pyside6)
 Requires:       python3-dbus-python
-Requires:       hicolor-icon-theme >= 0.17
 Requires:       acl
 
 %description

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -69,6 +69,7 @@ cd %{_builddir}/%{name}-%{version}
 
 %{_datadir}/fcitx5-lotus/
 %{_datadir}/applications/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop
+%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
 %{_datadir}/icons/hicolor/scalable/apps/*fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/scalable/status/fcitx-lotus*.svg

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -27,7 +27,7 @@ Requires:       fcitx5
 Requires:       python3-QtPy
 Requires:       (python3-PyQt6 or python3-pyside6)
 Requires:       python3-dbus-python
-Requires:       hicolor-icon-theme
+Requires:       hicolor-icon-theme >= 0.17
 Requires:       acl
 
 %description
@@ -35,6 +35,7 @@ Vietnamese input method for fcitx5
 
 %prep
 %setup -q
+find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
 %cmake
@@ -45,6 +46,7 @@ cd %{_builddir}/%{name}-%{version}
 %install
 %cmake_install
 %find_lang %{name}
+find %{buildroot} -type d -name __pycache__ -exec rm -rf {} +
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -22,7 +22,7 @@ BuildRequires:  sysuser-tools
 Requires(pre):  sysuser-shadow >= 3.1
 BuildRequires:  rsvg-convert
 BuildRequires:  hicolor-icon-theme
-BuildRequires:  breeze-icon-theme
+BuildRequires:  kf6-breeze-icons
 
 %{?systemd_requires}
 Requires:       fcitx5

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -21,8 +21,6 @@ BuildRequires:  python-rpm-macros
 BuildRequires:  sysuser-tools
 Requires(pre):  sysuser-shadow >= 3.1
 BuildRequires:  rsvg-convert
-BuildRequires:  hicolor-icon-theme
-BuildRequires:  kf6-breeze-icons
 
 %{?systemd_requires}
 Requires:       fcitx5
@@ -75,9 +73,15 @@ cd %{_builddir}/%{name}-%{version}
 %{_datadir}/icons/hicolor/scalable/apps/*fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/scalable/status/fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/*/status/fcitx-lotus*.png
+%dir %{_datadir}/icons/breeze
+%dir %{_datadir}/icons/breeze/status
+%dir %{_datadir}/icons/breeze/status/24
 %{_datadir}/icons/breeze/status/*/fcitx-lotus*.svg
+
+%dir %{_datadir}/icons/breeze-dark
+%dir %{_datadir}/icons/breeze-dark/status
+%dir %{_datadir}/icons/breeze-dark/status/24
 %{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
-%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
 %pre -f lotus.pre
 

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -37,14 +37,12 @@ Vietnamese input method for fcitx5
 find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
-export PYTHONDONTWRITEBYTECODE=1
-%cmake
+%cmake -DLOTUS_BYTECOMPILE_PYTHON=OFF
 %cmake_build
 cd %{_builddir}/%{name}-%{version}
 %sysusers_generate_pre build/misc/user-lotus.conf lotus lotus.conf
 
 %install
-export PYTHONDONTWRITEBYTECODE=1
 %cmake_install
 %find_lang %{name}
 

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -28,6 +28,7 @@ Requires:       python3-QtPy
 Requires:       (python3-PyQt6 or python3-pyside6)
 Requires:       python3-dbus-python
 Requires:       acl
+%set_build_env export PYTHONDONTWRITEBYTECODE=1
 
 %description
 Vietnamese input method for fcitx5
@@ -45,7 +46,6 @@ cd %{_builddir}/%{name}-%{version}
 %install
 %cmake_install
 %find_lang %{name}
-find %{buildroot} -type d -name __pycache__ -exec rm -rf {} +
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -12,17 +12,15 @@ BuildRequires:  gcc-c++
 BuildRequires:  glibc-devel
 BuildRequires:  fcitx5-devel
 BuildRequires:  libinput-devel
-BuildRequires:  systemd-rpm-macros
 BuildRequires:  systemd-devel
 BuildRequires:  libX11-devel
 
 BuildRequires:  go
-BuildRequires:  python-rpm-macros
 BuildRequires:  sysuser-tools
 Requires(pre):  sysuser-shadow >= 3.1
 BuildRequires:  rsvg-convert
 
-%{?systemd_requires}
+%{?systemd_ordering}
 Requires:       fcitx5
 Requires:       python3-QtPy
 Requires:       (python3-PyQt6 or python3-pyside6)

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -28,7 +28,6 @@ Requires:       python3-QtPy
 Requires:       (python3-PyQt6 or python3-pyside6)
 Requires:       python3-dbus-python
 Requires:       acl
-%set_build_env export PYTHONDONTWRITEBYTECODE=1
 
 %description
 Vietnamese input method for fcitx5
@@ -38,12 +37,14 @@ Vietnamese input method for fcitx5
 find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
+export PYTHONDONTWRITEBYTECODE=1
 %cmake
 %cmake_build
 cd %{_builddir}/%{name}-%{version}
 %sysusers_generate_pre build/misc/user-lotus.conf lotus lotus.conf
 
 %install
+export PYTHONDONTWRITEBYTECODE=1
 %cmake_install
 %find_lang %{name}
 

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -74,13 +74,16 @@ cd %{_builddir}/%{name}-%{version}
 %{_datadir}/icons/hicolor/scalable/apps/*fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/scalable/status/fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/*/status/fcitx-lotus*.png
+
 %dir %{_datadir}/icons/breeze
 %dir %{_datadir}/icons/breeze/status
+%dir %{_datadir}/icons/breeze/status/22
 %dir %{_datadir}/icons/breeze/status/24
 %{_datadir}/icons/breeze/status/*/fcitx-lotus*.svg
 
 %dir %{_datadir}/icons/breeze-dark
 %dir %{_datadir}/icons/breeze-dark/status
+%dir %{_datadir}/icons/breeze-dark/status/22
 %dir %{_datadir}/icons/breeze-dark/status/24
 %{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
 

--- a/settings-gui/CMakeLists.txt
+++ b/settings-gui/CMakeLists.txt
@@ -3,6 +3,8 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 set(SETTINGS_GUI_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/settings-gui")
 set(SETTINGS_GUI_FULL_PATH "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/settings-gui")
 
+option(LOTUS_BYTECOMPILE_PYTHON "Byte-compile Python scripts during install" ON)
+
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/version.py.in"
     "${CMAKE_CURRENT_BINARY_DIR}/version.py"
@@ -30,12 +32,14 @@ exec \"${SETTINGS_GUI_FULL_PATH}/main.py\" \"$@\"
 install(PROGRAMS "${LAUNCHER_SCRIPT}"
         DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
-install(CODE "
-    message(STATUS \"Byte-compiling Python scripts...\")
-    execute_process(
-        COMMAND \"${Python3_EXECUTABLE}\" -m compileall -q \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${SETTINGS_GUI_INSTALL_DIR}\"
-    )
-")
+if(LOTUS_BYTECOMPILE_PYTHON)
+    install(CODE "
+        message(STATUS \"Byte-compiling Python scripts...\")
+        execute_process(
+            COMMAND \"${Python3_EXECUTABLE}\" -m compileall -q \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${SETTINGS_GUI_INSTALL_DIR}\"
+        )
+    ")
+endif()
 
 fcitx5_translate_desktop_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop.in"


### PR DESCRIPTION
# Mô tả
PR này khai báo thư mục cha %{_datadir}/licenses/%{name} và %{_modulesloaddir}, và mấy cái thư mục icon , dùng lệnh/macro để tự động chuyển đổi shebang /usr/bin/env python3 thành /usr/bin/python3 theo [Fedora](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_shebangs) và [OpenSUSE](https://en.opensuse.org/openSUSE:Packaging_Python#Dependency_on_/usr/bin/python3), tạo/dùng biến CMake để tắt đi việc Cmake tự tạo pycache theo tiêu chuẩn của [Fedora](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_source_files_and_bytecode_cache) và [Debian & Ubuntu](https://www.debian.org/doc/packaging-manuals/python-policy/#modules-byte-compilation), xoá đi yêu cầu hicolor-icon-theme vì [OpenSUSE](https://en.opensuse.org/openSUSE:Packaging_scriptlet_snippets#GTK+_icon_cache), [Fedora](https://pagure.io/packaging-committee/issue/736/) và [Debian & Ubuntu](https://manpages.debian.org/unstable/debhelper/dh_icons.1.en.html#DESCRIPTION) 


## Loại thay đổi

- [ ] Tính năng mới
- [ ] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD
- [x] Cải tiến đóng gói
## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ ] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [ ] Build C++ thành công (`cmake .. && make`)
- [ ] Test pass (`cd bamboo/ && go test -race ./...`)
- [ ] Đã rebase với nhánh `dev` mới nhất
- [x] Các CI checks pass:
