### PR TITLE
Fix DEB/RPM

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,6 +3,8 @@ Section: utils
 Priority: optional
 Maintainer: Nguyen Hoang Ky <nhktmdzhg@gmail.com>
 Build-Depends: debhelper-compat (= 13),
+               dh-python,
+               dh-sequence-python3,
                cmake,
                g++,
                golang,
@@ -21,5 +23,5 @@ Standards-Version: 4.6.0
 
 Package: fcitx5-lotus
 Architecture: any
-Depends: acl, fcitx5, fcitx5-data, udev, hicolor-icon-theme, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${misc:Depends}, ${shlibs:Depends}
+Depends: acl, fcitx5, fcitx5-data, udev, python3-qtpy, python3-dbus, python3-qtpy-pyqt6 | python3-qtpy-pyside6 | python3-qtpy-pyqt5 | python3-pyqt5, ${misc:Depends}, ${shlibs:Depends}, ${python3:Depends}
 Description: Vietnamese input method for fcitx5

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,0 +1,26 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: fcitx5-lotus
+Upstream-Contact: Nguyen Hoang Ky <nhktmdzhg@gmail.com>
+Source: https://github.com/LotusInputMethod/fcitx5-lotus
+
+Files: *
+Copyright: 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com>
+License: GPL-3.0-or-later
+
+Files: debian/*
+Copyright: 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com>
+License: GPL-3.0-or-later
+
+License: GPL-3.0-or-later
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,44 +1,17 @@
 #!/bin/sh
 set -e
 
-blue='\033[1;34m'
-green='\033[1;32m'
-yellow='\033[1;33m'
-bold='\033[1;1m'
-all_off='\033[0m'
-
-REAL_USER="${SUDO_USER:-${PKEXEC_UID:+$(id -nu "$PKEXEC_UID" 2>/dev/null)}}"
-REAL_USER="${REAL_USER:-$(logname 2>/dev/null || id -nu 1000 2>/dev/null || echo "$USER")}"
-
-if [ "$1" = "configure" ]; then
-    modprobe uinput || true
-    if command -v udevadm >/dev/null; then
-        udevadm control --reload-rules || true
-        udevadm trigger || true
-    fi
-    systemd-sysusers || true
-    
-    if [ -z "$2" ]; then
-        if ! systemctl enable --now "fcitx5-lotus-server@${REAL_USER}.service" 2>/dev/null; then
-            printf "%b\n" "  ${yellow}⚠ Chạy lệnh sau để bật service: sudo systemctl enable --now fcitx5-lotus-server@${REAL_USER}.service${all_off}"
-        fi
-        
-        killall ibus-daemon 2>/dev/null || true
-        USER_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
-        rm -f "$USER_HOME/.config/autostart/ibus"* 2>/dev/null || true
-        
-        printf "%b\n" "${blue}─────────────────────────────────────────────${all_off}"
-        printf "%b\n" "${bold}Hướng dẫn sau cài đặt:${all_off}"
-        printf "%b\n" "  1. Cấu hình bộ gõ: Chạy ${green}fcitx5-configtool${all_off} để thêm Lotus."
-        printf "%b\n" "${bold}Các bước bổ sung nếu cần:${all_off}"
-        printf "%b\n" "  - Wayland (KDE/Hyprland): Thiết lập Virtual Keyboard & Permission."
-        printf "%b\n" "  - Kanata: Exclude 'Lotus-Uinput-Server' trong cấu hình."
-        printf "%b\n" "${blue}─────────────────────────────────────────────${all_off}"
-        echo ""
-    else
-        systemctl restart "fcitx5-lotus-server@${REAL_USER}.service" || true
-    fi
+if [ "$1" = "configure" ] && [ -z "$2" ]; then
+    echo "─────────────────────────────────────────────"
+    echo "Hướng dẫn sau cài đặt:"
+    echo "  1. Cấu hình bộ gõ: Chạy fcitx5-configtool để thêm Lotus."
+    echo "  2. Bật dịch vụ systemd: sudo systemctl enable --now fcitx5-lotus-server@\$USER.service"
+    echo "Các bước bổ sung nếu cần:"
+    echo "  - Wayland (KDE/Hyprland): Thiết lập Virtual Keyboard & Permission."
+    echo "  - Kanata: Exclude 'Lotus-Uinput-Server' trong cấu hình."
+    echo "─────────────────────────────────────────────"
 fi
 
 #DEBHELPER#
+
 exit 0

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,15 +1,14 @@
 #!/usr/bin/make -f
-
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
 	dh $@ --buildsystem=cmake
 
-execute_after_dh_auto_install:
-	@echo "Rewriting Python shebangs..."
-	find debian/fcitx5-lotus/usr -type f \
-		-exec grep -Il '^#!.*python' {} \; 2>/dev/null | \
-		xargs -r sed -i '1s|^#!.*python.*|#!/usr/bin/python3|'
+override_dh_python3:
+	dh_python3 --shebang=/usr/bin/python3
 
 override_dh_dwz:
 	@echo "Skipping dh_dwz (incompatible with Go/mixed debug sections)"
+
+override_dh_auto_configure:
+	dh_auto_configure -- -DLOTUS_BYTECOMPILE_PYTHON=OFF

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -10,24 +10,20 @@ BuildRequires:  cmake
 BuildRequires:  extra-cmake-modules
 BuildRequires:  gcc-c++
 BuildRequires:  gettext-devel
-BuildRequires:  glibc-devel
 BuildRequires:  cmake(Fcitx5Core)
 BuildRequires:  libinput-devel
-BuildRequires:  systemd-rpm-macros
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  libX11-devel
 
 BuildRequires:  golang
-BuildRequires:  python3
+BuildRequires:  python3-devel
 BuildRequires:  librsvg2-tools
 
-%{?systemd_requires}
-Requires:       fcitx5-data
+%{?systemd_ordering}
 Requires:       fcitx5
 Requires:       python3-QtPy
 Requires:       (python3-pyqt6 or python3-pyside6)
 Requires:       python3-dbus
-Requires:       hicolor-icon-theme
 Requires:       acl
 
 %description
@@ -37,17 +33,21 @@ Vietnamese input method for fcitx5
 %setup -q
 
 %build
-%cmake
+%cmake -DLOTUS_BYTECOMPILE_PYTHON=OFF
 %cmake_build
 
 %install
 %cmake_install
 %find_lang %{name}
+%py_byte_compile %{__python3} %{buildroot}%{_datadir}/fcitx5-lotus
+
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt
 %{_datadir}/licenses/%{name}/LGPL-2.1-or-later.txt
 
+%dir %{_datadir}/licenses/%{name}
+%dir %{_modulesloaddir}
 %{_bindir}/fcitx5-lotus-server
 %{_bindir}/fcitx5-lotus-settings
 
@@ -64,14 +64,23 @@ Vietnamese input method for fcitx5
 %{_datadir}/fcitx5/lotus/
 %{_datadir}/fcitx5-lotus/
 %{_datadir}/applications/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop
+%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
 %{_datadir}/icons/hicolor/scalable/apps/*fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/scalable/status/fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/*/status/fcitx-lotus*.png
-%{_datadir}/icons/breeze/status/*/fcitx-lotus*.svg
-%{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
 
-%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
+%dir %{_datadir}/icons/breeze
+%dir %{_datadir}/icons/breeze/status
+%dir %{_datadir}/icons/breeze/status/22
+%dir %{_datadir}/icons/breeze/status/24
+%{_datadir}/icons/breeze/status/*/fcitx-lotus*.svg
+
+%dir %{_datadir}/icons/breeze-dark
+%dir %{_datadir}/icons/breeze-dark/status
+%dir %{_datadir}/icons/breeze-dark/status/22
+%dir %{_datadir}/icons/breeze-dark/status/24
+%{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
 
 %post
 %systemd_post fcitx5-lotus-server@.service

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -12,22 +12,19 @@ BuildRequires:  gcc-c++
 BuildRequires:  glibc-devel
 BuildRequires:  fcitx5-devel
 BuildRequires:  libinput-devel
-BuildRequires:  systemd-rpm-macros
 BuildRequires:  systemd-devel
 BuildRequires:  libX11-devel
 
 BuildRequires:  go
-BuildRequires:  python-rpm-macros
 BuildRequires:  sysuser-tools
 Requires(pre):  sysuser-shadow >= 3.1
 BuildRequires:  rsvg-convert
 
-%{?systemd_requires}
+%{?systemd_ordering}
 Requires:       fcitx5
 Requires:       python3-QtPy
 Requires:       (python3-PyQt6 or python3-pyside6)
 Requires:       python3-dbus-python
-Requires:       hicolor-icon-theme
 Requires:       acl
 
 %description
@@ -35,6 +32,7 @@ Vietnamese input method for fcitx5
 
 %prep
 %setup -q
+find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
 %cmake
@@ -50,6 +48,8 @@ cd %{_builddir}/%{name}-%{version}
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt
 %{_datadir}/licenses/%{name}/LGPL-2.1-or-later.txt
 
+%dir %{_datadir}/licenses/%{name}
+%dir %{_modulesloaddir}
 %{_bindir}/fcitx5-lotus-server
 %{_bindir}/fcitx5-lotus-settings
 
@@ -67,18 +67,28 @@ cd %{_builddir}/%{name}-%{version}
 
 %{_datadir}/fcitx5-lotus/
 %{_datadir}/applications/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop
+%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
 %{_datadir}/icons/hicolor/scalable/apps/*fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/scalable/status/fcitx-lotus*.svg
 %{_datadir}/icons/hicolor/*/status/fcitx-lotus*.png
+
+%dir %{_datadir}/icons/breeze
+%dir %{_datadir}/icons/breeze/status
+%dir %{_datadir}/icons/breeze/status/22
+%dir %{_datadir}/icons/breeze/status/24
 %{_datadir}/icons/breeze/status/*/fcitx-lotus*.svg
+
+%dir %{_datadir}/icons/breeze-dark
+%dir %{_datadir}/icons/breeze-dark/status
+%dir %{_datadir}/icons/breeze-dark/status/22
+%dir %{_datadir}/icons/breeze-dark/status/24
 %{_datadir}/icons/breeze-dark/status/*/fcitx-lotus*.svg
-%{_datadir}/metainfo/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml
 
 %pre -f lotus.pre
 
 %post
-%systemd_post fcitx5-lotus-server@.service
+%service_add_post fcitx5-lotus-server@.service
 
 if [ $1 -eq 1 ]; then
     echo "--- Cấu hình Lotus ---"
@@ -103,10 +113,10 @@ elif [ $1 -eq 2 ]; then
 fi
 
 %preun
-%systemd_preun fcitx5-lotus-server@.service
+%service_del_preun fcitx5-lotus-server@.service
 
 %postun
-%systemd_postun_with_restart fcitx5-lotus-server@.service
+%service_del_postun fcitx5-lotus-server@.service
 
 %changelog
 * Sat Aug 29 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.6-1

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -35,7 +35,7 @@ Vietnamese input method for fcitx5
 find . -type f -name '*.py' -exec sed -i '1s|^#!.*env python3|#!/usr/bin/python3|' {} +
 
 %build
-%cmake
+%cmake -DLOTUS_BYTECOMPILE_PYTHON=OFF
 %cmake_build
 cd %{_builddir}/%{name}-%{version}
 %sysusers_generate_pre build/misc/user-lotus.conf lotus lotus.conf
@@ -43,6 +43,7 @@ cd %{_builddir}/%{name}-%{version}
 %install
 %cmake_install
 %find_lang %{name}
+%py3_compile %{buildroot}%{_datadir}/fcitx5-lotus
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt

--- a/settings-gui/CMakeLists.txt
+++ b/settings-gui/CMakeLists.txt
@@ -3,6 +3,8 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 set(SETTINGS_GUI_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/settings-gui")
 set(SETTINGS_GUI_FULL_PATH "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/settings-gui")
 
+option(LOTUS_BYTECOMPILE_PYTHON "Byte-compile Python scripts during install" ON)
+
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/version.py.in"
     "${CMAKE_CURRENT_BINARY_DIR}/version.py"
@@ -30,12 +32,14 @@ exec \"${SETTINGS_GUI_FULL_PATH}/main.py\" \"$@\"
 install(PROGRAMS "${LAUNCHER_SCRIPT}"
         DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
-install(CODE "
-    message(STATUS \"Byte-compiling Python scripts...\")
-    execute_process(
-        COMMAND \"${Python3_EXECUTABLE}\" -m compileall -q \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${SETTINGS_GUI_INSTALL_DIR}\"
-    )
-")
+if(LOTUS_BYTECOMPILE_PYTHON)
+    install(CODE "
+        message(STATUS \"Byte-compiling Python scripts...\")
+        execute_process(
+            COMMAND \"${Python3_EXECUTABLE}\" -m compileall -q \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${SETTINGS_GUI_INSTALL_DIR}\"
+        )
+    ")
+endif()
 
 fcitx5_translate_desktop_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/org.fcitx.Fcitx5.Addon.Lotus.Settings.desktop.in"

--- a/settings-gui/CMakeLists.txt
+++ b/settings-gui/CMakeLists.txt
@@ -36,7 +36,8 @@ if(LOTUS_BYTECOMPILE_PYTHON)
     install(CODE "
         message(STATUS \"Byte-compiling Python scripts...\")
         execute_process(
-            COMMAND \"${Python3_EXECUTABLE}\" -m compileall -q \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${SETTINGS_GUI_INSTALL_DIR}\"
+            COMMAND \"${Python3_EXECUTABLE}\" -m compileall -q -o 0 -o 1 -d \"${SETTINGS_GUI_FULL_PATH}\"
+                \"\$ENV{DESTDIR}${SETTINGS_GUI_FULL_PATH}\"
         )
     ")
 endif()


### PR DESCRIPTION
# Mô tả
PR này khai báo thư mục cha %{_datadir}/licenses/%{name} và %{_modulesloaddir}, và mấy cái thư mục icon , dùng lệnh/macro để tự động chuyển đổi shebang /usr/bin/env python3 thành /usr/bin/python3 theo [Fedora](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_shebangs) và [OpenSUSE](https://en.opensuse.org/openSUSE:Packaging_Python#Dependency_on_/usr/bin/python3), tạo/dùng biến CMake để tắt đi việc Cmake tự tạo pycache theo tiêu chuẩn của [Fedora](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_source_files_and_bytecode_cache) và [Debian & Ubuntu](https://www.debian.org/doc/packaging-manuals/python-policy/#modules-byte-compilation), xoá đi yêu cầu hicolor-icon-theme vì [OpenSUSE](https://en.opensuse.org/openSUSE:Packaging_scriptlet_snippets#GTK+_icon_cache), [Fedora](https://pagure.io/packaging-committee/issue/736/) và [Debian & Ubuntu](https://manpages.debian.org/unstable/debhelper/dh_icons.1.en.html#DESCRIPTION), thay đổi macro service OpenSUSE cho đúng và thêm 1 số cái khác....

## Loại thay đổi

- [ ] Tính năng mới
- [ ] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD
- [x] Cải tiến đóng gói

## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ ] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [ ] Build C++ thành công (`cmake .. && make`)
- [ ] Test pass (`cd bamboo/ && go test -race ./...`)
- [ ] Đã rebase với nhánh `dev` mới nhất
- [x] Các CI checks pass:
