### PR TITLE
Fix rpm lint and opensuse deduplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(fcitx5-lotus VERSION 3.5.7)
+project(fcitx5-lotus VERSION 3.5.8)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(REQUIRED_FCITX_VERSION 5.0.14)

--- a/nix/packages/fcitx5-lotus/default.nix
+++ b/nix/packages/fcitx5-lotus/default.nix
@@ -11,31 +11,41 @@
   hicolor-icon-theme,
   kdePackages,
   libinput,
-  libx11,
   librsvg,
+  libx11,
   pkg-config,
   python3,
   qt6,
   udev,
 }:
-stdenv.mkDerivation rec {
+
+let
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      dbus-python
+      pyqt6
+      qtpy
+    ]
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "fcitx5-lotus";
   version = "3.5.7";
 
   src = fetchFromGitHub {
     owner = "LotusInputMethod";
     repo = "fcitx5-lotus";
-    tag = "v${version}";
-    fetchSubmodules = true;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-IQFklfLrccVm/SW8dpcplbWfoYJNoS4nMMdkuOzOgdo=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
     cmake
-    kdePackages.extra-cmake-modules
     gettext
     go
     hicolor-icon-theme
+    kdePackages.extra-cmake-modules
     librsvg
     pkg-config
     qt6.wrapQtAppsHook
@@ -44,23 +54,19 @@ stdenv.mkDerivation rec {
   buildInputs = [
     acl
     fcitx5
+    kdePackages.extra-cmake-modules
     libinput
     libx11
-    (python3.withPackages (
-      ps: with ps; [
-        pyqt6
-        dbus-python
-        qtpy
-      ]
-    ))
+    pythonEnv
     qt6.qtbase
+    qt6.qtsvg
     udev
   ];
 
   vendorDir =
     (buildGoModule {
       pname = "fcitx5-lotus-go-modules";
-      inherit version src;
+      inherit (finalAttrs) version src;
       modRoot = "bamboo";
       vendorHash = "sha256-Y8sh1PqmBjXko2X9YOxwCrtrGLQ565aewrq4sRvLdpw=";
     }).goModules;
@@ -73,50 +79,38 @@ stdenv.mkDerivation rec {
     cp -r $vendorDir bamboo/vendor
   '';
 
-  cmakeFlags = [
-    "-DGO_FLAGS=-mod=vendor"
-  ];
-
-  # change checking exe_path logic to make it work on NixOS since executable files on NixOS are not located in /usr/bin
   postPatch = ''
     substituteInPlace src/lotus-monitor.cpp \
       --replace-fail 'strcmp(exe_path, "/usr/bin/fcitx5-lotus-server") == 0' \
-                '(strncmp(exe_path, "/nix/store/", 11) == 0 && strlen(exe_path) >= 24 && strcmp(exe_path + strlen(exe_path) - 24, "/bin/fcitx5-lotus-server") == 0)'
+                     '(strncmp(exe_path, "/nix/store/", 11) == 0 && strlen(exe_path) >= 24 && strcmp(exe_path + strlen(exe_path) - 24, "/bin/fcitx5-lotus-server") == 0)'
 
     substituteInPlace server/lotus-server.cpp \
       --replace-fail 'strcmp(exe_path, "/usr/bin/fcitx5") == 0' \
-                '(strncmp(exe_path, "/nix/store/", 11) == 0 && strlen(exe_path) >= 11 && strcmp(exe_path + strlen(exe_path) - 11, "/bin/fcitx5") == 0)'
-
-    substituteInPlace settings-gui/i18n.py \
-      --replace-fail 'localedir = "/usr/share/locale"' \
-                      'localedir = "'"$out"'/share/locale"'
-
-    substituteInPlace settings-gui/ui/pages/dict_editor.py \
-      --replace-fail \
-'paths = [
-            "/usr/share/fcitx5/lotus/vietnamese.cm.dict",
-            "/usr/local/share/fcitx5/lotus/vietnamese.cm.dict",
-        ]' \
-'paths = [
-            "'"$out"'/share/fcitx5/lotus/vietnamese.cm.dict",
-        ]'
+                     '(strncmp(exe_path, "/nix/store/", 11) == 0 && strlen(exe_path) >= 11 && strcmp(exe_path + strlen(exe_path) - 11, "/bin/fcitx5") == 0)'
 
     substituteInPlace src/lotus-engine.cpp \
       --replace-fail '/usr/share/icons/hicolor' '/run/current-system/sw/share/icons/hicolor'
+
+    substituteInPlace settings-gui/i18n.py \
+      --replace-fail 'localedir = "/usr/share/locale"' 'localedir = "'"$out"'/share/locale"'
+
+    substituteInPlace settings-gui/ui/pages/dict_editor.py \
+      --replace-fail '"/usr/share/fcitx5/lotus/vietnamese.cm.dict"' '"'"$out"'/share/fcitx5/lotus/vietnamese.cm.dict"'
   '';
 
   postInstall = ''
     substituteInPlace $out/lib/udev/rules.d/99-lotus.rules \
       --replace-fail "/usr/bin/setfacl" "${acl}/bin/setfacl"
+
     substituteInPlace $out/lib/systemd/system/fcitx5-lotus-server@.service \
-      --replace-fail "/usr/bin/setfacl" "${acl}/bin/setfacl"
-    substituteInPlace $out/lib/systemd/system/fcitx5-lotus-server@.service \
+      --replace-fail "/usr/bin/setfacl" "${acl}/bin/setfacl" \
       --replace-fail "/usr/bin/fcitx5-lotus-server" "$out/bin/fcitx5-lotus-server"
   '';
 
   postFixup = ''
     patchShebangs $out/share/fcitx5-lotus/settings-gui
-    wrapQtApp $out/bin/fcitx5-lotus-settings
+    wrapQtApp $out/bin/fcitx5-lotus-settings \
+      --prefix XDG_DATA_DIRS : "${hicolor-icon-theme}/share"
   '';
 
   meta = with lib; {
@@ -125,4 +119,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     platforms = platforms.linux;
   };
-}
+})

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,5 +1,5 @@
-fcitx5-lotus (3.5.7-1) unstable; urgency=medium
+fcitx5-lotus (3.5.8-1) unstable; urgency=medium
 
-  * Fix some small bug
+  * Fix systemd-sysusers don't run automatically
 
- -- Nguyen Hoang Ky <nhktmdzhg@gmail.com>  Thu, 03 Sep 2026 11:44:00 +0700
+ -- Nguyen Hoang Ky <nhktmdzhg@gmail.com>  Fri, 04 Sep 2026 10:00:00 +0700

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,15 +1,32 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "configure" ] && [ -z "$2" ]; then
-    echo "─────────────────────────────────────────────"
-    echo "Hướng dẫn sau cài đặt:"
-    echo "  1. Cấu hình bộ gõ: Chạy fcitx5-configtool để thêm Lotus."
-    echo "  2. Bật dịch vụ systemd: sudo systemctl enable --now fcitx5-lotus-server@\$USER.service"
-    echo "Các bước bổ sung nếu cần:"
-    echo "  - Wayland (KDE/Hyprland): Thiết lập Virtual Keyboard & Permission."
-    echo "  - Kanata: Exclude 'Lotus-Uinput-Server' trong cấu hình."
-    echo "─────────────────────────────────────────────"
+if [ "$1" = "configure" ]; then
+    if command -v systemd-sysusers >/dev/null 2>&1; then
+        systemd-sysusers lotus.conf
+    fi
+    
+    if [ -z "$2" ]; then
+        echo "--- Cấu hình Lotus ---"
+        echo "Hướng dẫn sau cài đặt:"
+        echo "1. Kích hoạt Server cho user của bạn:"
+        echo "   sudo systemctl enable --now fcitx5-lotus-server@\$(whoami).service"
+        echo ""
+        echo "2. Cấu hình Fcitx5:"
+        echo "   - Mở 'Fcitx5 Configuration', thêm bộ gõ Lotus"
+        echo ""
+        echo "3. Lưu ý cho Wayland (KDE):"
+        echo "   - Hãy chọn 'Fcitx 5' trong phần Virtual Keyboard của hệ thống."
+        echo "------------------------------------------------"
+    else
+        echo "--- Cấu hình Lotus ---"
+        echo "Hướng dẫn sau cập nhật:"
+        echo "1. Khởi động lại Server cho user của bạn:"
+        echo "   sudo systemctl restart fcitx5-lotus-server@\$(whoami).service"
+        echo ""
+        echo "2. Cấu hình Fcitx5:"
+        echo "   - Mở 'Fcitx5 Configuration', nhấn restart để khởi động lại."
+    fi
 fi
 
 #DEBHELPER#

--- a/packaging/rpm/fedora/fcitx5-lotus.spec
+++ b/packaging/rpm/fedora/fcitx5-lotus.spec
@@ -1,5 +1,5 @@
 Name:           fcitx5-lotus
-Version:        3.5.7
+Version:        3.5.8
 Release:        1
 Summary:        Vietnamese input method for fcitx5
 License:        GPL-3.0-or-later
@@ -115,5 +115,5 @@ fi
 %systemd_postun_with_restart fcitx5-lotus-server@.service
 
 %changelog
-* Thu Sep 03 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.7-1
-- Fix some small bug
+* Fri Sep 04 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.8-1
+- Nothing

--- a/packaging/rpm/opensuse/fcitx5-lotus.changes
+++ b/packaging/rpm/opensuse/fcitx5-lotus.changes
@@ -1,0 +1,4 @@
+-------------------------------------------------------------------
+Fri Sep 04 01:06:21 UTC 2026 - Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.7-1
+
+- Fix some small bug

--- a/packaging/rpm/opensuse/fcitx5-lotus.changes
+++ b/packaging/rpm/opensuse/fcitx5-lotus.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 04 05:27:09 UTC 2026 - Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.8-1
+
+- Nothing
+
+-------------------------------------------------------------------
 Fri Sep 04 01:06:21 UTC 2026 - Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.7-1
 
 - Fix some small bug

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -19,6 +19,7 @@ BuildRequires:  go
 BuildRequires:  sysuser-tools
 Requires(pre):  sysuser-shadow >= 3.1
 BuildRequires:  rsvg-convert
+BuildRequires: fdupes   
 
 %{?systemd_ordering}
 Requires:       fcitx5
@@ -42,8 +43,9 @@ cd %{_builddir}/%{name}-%{version}
 
 %install
 %cmake_install
-%find_lang %{name}
 %py3_compile %{buildroot}%{_datadir}/fcitx5-lotus
+%find_lang %{name}
+%fdupes %{buildroot}%{_datadir}/icons
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt
@@ -119,6 +121,6 @@ fi
 %postun
 %service_del_postun fcitx5-lotus-server@.service
 
-%changelog
-* Thu Sep 03 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.7-1
-- Fix some small bug
+%check
+# Upstream does not provide a test suite
+true

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -1,5 +1,5 @@
 Name:           fcitx5-lotus
-Version:        3.5.7
+Version:        3.5.8
 Release:        1
 Summary:        Vietnamese input method for fcitx5
 License:        GPL-3.0-or-later


### PR DESCRIPTION
# Mô tả

PR này thêm fdupes, file .changes tách biệt cho OpenSUSE, đã build thành công trên Open Build Service với 0 errors, 0 warnings, 0 badness

## Loại thay đổi

- [ ] Tính năng mới
- [ ] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD
- [x] Cải tiến đóng gói

## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ ] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [ ] Build C++ thành công (`cmake .. && make`)
- [ ] Test pass (`cd bamboo/ && go test -race ./...`)
- [ ] Đã rebase với nhánh `dev` mới nhất
- [ ] Các CI checks pass:
