### PR TITLE
Fix rpm lint

### DIFF
--- a/packaging/rpm/opensuse/fcitx5-lotus.changes
+++ b/packaging/rpm/opensuse/fcitx5-lotus.changes
@@ -1,0 +1,9 @@
+-------------------------------------------------------------------
+Fri Sep 04 05:27:09 UTC 2026 - Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.8-1
+
+- Nothing
+
+-------------------------------------------------------------------
+Fri Sep 04 01:06:21 UTC 2026 - Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.7-1
+
+- Fix some small bug

--- a/packaging/rpm/opensuse/fcitx5-lotus.spec
+++ b/packaging/rpm/opensuse/fcitx5-lotus.spec
@@ -42,8 +42,8 @@ cd %{_builddir}/%{name}-%{version}
 
 %install
 %cmake_install
-%find_lang %{name}
 %py3_compile %{buildroot}%{_datadir}/fcitx5-lotus
+%find_lang %{name}
 
 %files -f %{name}.lang
 %{_datadir}/licenses/%{name}/GPL-3.0-or-later.txt
@@ -119,6 +119,6 @@ fi
 %postun
 %service_del_postun fcitx5-lotus-server@.service
 
-%changelog
-* Fri Sep 04 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com> - 3.5.8-1
-- Nothing
+%check
+# Upstream does not provide a test suite
+true


### PR DESCRIPTION
# Mô tả
tách changelog riêng cho OpenSUSE để cung cấp thêm cả SOURCE_DATE_EPOCH , tắt %check cho OpenSUSE

## Loại thay đổi

- [ ] Tính năng mới
- [ ] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD
- [x] Cải tiến đóng gói
## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ ] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [ ] Build C++ thành công (`cmake .. && make`)
- [ ] Test pass (`cd bamboo/ && go test -race ./...`)
- [ ] Đã rebase với nhánh `dev` mới nhất
- [x] Các CI checks pass:
