### PR TITLE
Adds a headless CTest harness for Lotus regression testing using production engine code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,18 @@ jobs:
         uses: fcitx/github-actions@cmake
         with:
           path: fcitx5-lotus
+          # Enable building the headless integration test suite alongside the addon
+          cmake-option: -DBUILD_TESTING=ON
+      # Log all discovered CTest targets in job output for quick triage and auditability
+      - name: Discover tests
+        run: |
+          ctest --test-dir fcitx5-lotus/build -N
+      # Execute test suite:
+      # - --output-on-failure: dumps stdout/stderr immediately if an assertion fails
+      # - --no-tests=error: ensures CI fails if test discovery yielded 0 tests (prevents false-positive passing builds)
       - name: Test
         run: |
-          ctest --test-dir fcitx5-lotus/build
+          ctest --test-dir fcitx5-lotus/build --output-on-failure --no-tests=error
       - name: CodeQL Analysis
         uses: github/codeql-action/analyze@v4.37.9
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.10)
 project(fcitx5-lotus VERSION 3.5.8)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(BUILD_TESTING "Build Lotus tests" OFF)
-include(CTest)
 
 # The addon entry point is intentionally excluded: each headless test links
 # the production implementation directly, without a reusable archive/object
@@ -52,6 +51,7 @@ add_subdirectory(misc)
 add_subdirectory(settings-gui)
 
 if (BUILD_TESTING)
+    include(CTest)
     add_subdirectory(test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,21 @@ cmake_minimum_required(VERSION 3.10)
 
 project(fcitx5-lotus VERSION 3.5.8)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+option(BUILD_TESTING "Build Lotus tests" OFF)
+include(CTest)
+
+# The addon entry point is intentionally excluded: each headless test links
+# the production implementation directly, without a reusable archive/object
+# target that could differ from the module build.
+set(fcitx_lotus_core_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lotus-engine.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lotus-state.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lotus-candidates.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lotus-utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lotus-monitor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/lotus-icon-resolver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/emoji.cpp
+)
 
 set(REQUIRED_FCITX_VERSION 5.0.14)
 find_package(ECM 1.0.0 REQUIRED)
@@ -35,6 +50,10 @@ add_subdirectory(data)
 add_subdirectory(server)
 add_subdirectory(misc)
 add_subdirectory(settings-gui)
+
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/org.fcitx.Fcitx5.Addon.Lotus.metainfo.xml.in.in"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,4 @@
-set(fcitx_lotus_sources
-  lotus.cpp
-  lotus-engine.cpp
-  lotus-state.cpp
-  lotus-candidates.cpp
-  lotus-utils.cpp
-  lotus-monitor.cpp
-  lotus-icon-resolver.cpp
-  emoji.cpp
-)
-
-add_library(lotus MODULE ${fcitx_lotus_sources})
+add_library(lotus MODULE lotus.cpp ${fcitx_lotus_core_sources})
 set_target_properties(lotus PROPERTIES OUTPUT_NAME "lotus")
 set_target_properties(lotus PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_options(lotus PRIVATE "-Wl,-exclude-libs,ALL")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,3 +39,5 @@ add_lotus_headless_test(preedit_smoke_client preedit-smoke-client.cpp "integrati
 add_lotus_headless_test(preedit_smoke_server preedit-smoke-server.cpp "integration;preedit")
 add_lotus_headless_test(smooth_buffered_key_replay
     smooth-buffered-key-replay.cpp "integration;smooth")
+add_lotus_headless_test(modifier_key_bypasses_surrounding_text
+    modifier-key-bypasses-surrounding-text.cpp "integration;surrounding")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,3 +35,4 @@ function(add_bamboo_test target source labels)
 endfunction()
 
 add_lotus_headless_test(preedit_lifecycle preedit-lifecycle.cpp "integration;preedit")
+add_lotus_headless_test(preedit_smoke_client preedit-smoke-client.cpp "integration;preedit")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,3 +36,4 @@ endfunction()
 
 add_lotus_headless_test(preedit_lifecycle preedit-lifecycle.cpp "integration;preedit")
 add_lotus_headless_test(preedit_smoke_client preedit-smoke-client.cpp "integration;preedit")
+add_lotus_headless_test(preedit_smoke_server preedit-smoke-server.cpp "integration;preedit")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,3 +33,5 @@ function(add_bamboo_test target source labels)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(${target} PROPERTIES LABELS "${labels}" TIMEOUT 20)
 endfunction()
+
+add_lotus_headless_test(preedit_lifecycle preedit-lifecycle.cpp "integration;preedit")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,3 +41,5 @@ add_lotus_headless_test(smooth_buffered_key_replay
     smooth-buffered-key-replay.cpp "integration;smooth")
 add_lotus_headless_test(modifier_key_bypasses_surrounding_text
     modifier-key-bypasses-surrounding-text.cpp "integration;surrounding")
+add_lotus_headless_test(emoji_history_page_navigation
+    emoji-history-page-navigation.cpp "integration;emoji")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,8 @@ add_lotus_headless_test(modifier_key_bypasses_surrounding_text
     modifier-key-bypasses-surrounding-text.cpp "integration;surrounding")
 add_lotus_headless_test(emoji_history_page_navigation
     emoji-history-page-navigation.cpp "integration;emoji")
+add_bamboo_test(numeric_macro_case_preservation
+    numeric-macro-case-preservation.cpp "unit;macro")
 
 add_executable(emoji_backspace_utf8
     test-emoji-backspace.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,3 +37,5 @@ endfunction()
 add_lotus_headless_test(preedit_lifecycle preedit-lifecycle.cpp "integration;preedit")
 add_lotus_headless_test(preedit_smoke_client preedit-smoke-client.cpp "integration;preedit")
 add_lotus_headless_test(preedit_smoke_server preedit-smoke-server.cpp "integration;preedit")
+add_lotus_headless_test(smooth_buffered_key_replay
+    smooth-buffered-key-replay.cpp "integration;smooth")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Helper macro to compile standalone headless integration test linked with Lotus engine.
+#
+# Usage:
+#   add_lotus_headless_test(<target_name> <source_file> "<labels>")
+# Example:
+#   add_lotus_headless_test(my_test my-test.cpp "integration;myfeature")
+function(add_lotus_headless_test target source labels)
+    add_executable(${target} ${source} ${fcitx_lotus_core_sources})
+    target_include_directories(${target} PRIVATE
+        ${PROJECT_BINARY_DIR}
+        ${PROJECT_SOURCE_DIR}/src
+    )
+    target_compile_definitions(${target} PRIVATE
+        FCITX5_LOTUS_SETTINGS_PATH="${CMAKE_INSTALL_FULL_BINDIR}/fcitx5-lotus-settings"
+        FCITX_LOTUS_ICON_DIR="${CMAKE_INSTALL_FULL_DATADIR}/icons/hicolor/scalable/apps"
+    )
+    target_link_libraries(${target} PRIVATE
+        Fcitx5::Core
+        Fcitx5::Config
+        Fcitx5::Module::Emoji
+        Bamboo::Core
+        Pthread::Pthread
+        X11::X11
+    )
+    add_test(NAME ${target} COMMAND ${target})
+    set_tests_properties(${target} PROPERTIES LABELS "${labels}" TIMEOUT 20)
+endfunction()
+
+# Helper macro to compile lightweight unit test linked with Bamboo engine core.
+function(add_bamboo_test target source labels)
+    add_executable(${target} ${source})
+    target_link_libraries(${target} PRIVATE Bamboo::Core)
+    add_test(NAME ${target} COMMAND ${target})
+    set_tests_properties(${target} PROPERTIES LABELS "${labels}" TIMEOUT 20)
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,3 +43,19 @@ add_lotus_headless_test(modifier_key_bypasses_surrounding_text
     modifier-key-bypasses-surrounding-text.cpp "integration;surrounding")
 add_lotus_headless_test(emoji_history_page_navigation
     emoji-history-page-navigation.cpp "integration;emoji")
+
+add_executable(emoji_backspace_utf8
+    test-emoji-backspace.cpp
+    ${PROJECT_SOURCE_DIR}/src/lotus-utils.cpp
+)
+target_include_directories(emoji_backspace_utf8 PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(emoji_backspace_utf8 PRIVATE
+    Fcitx5::Core
+)
+add_test(NAME emoji_backspace_utf8 COMMAND emoji_backspace_utf8)
+set_tests_properties(emoji_backspace_utf8 PROPERTIES
+    LABELS "unit;emoji"
+    TIMEOUT 20
+)

--- a/test/emoji-history-page-navigation.cpp
+++ b/test/emoji-history-page-navigation.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "lotus-engine.h"
+#include "test-input-context.h"
+
+#include <fcitx/candidatelist.h>
+#include <fcitx/inputpanel.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+    void reportFailure(const std::string& step, const std::string& expected, const std::string& actual, const std::string& meaning) {
+        std::cerr << "Step: " << step << '\n';
+        std::cerr << "Expected: " << expected << '\n';
+        std::cerr << "Actual: " << actual << '\n';
+        std::cerr << "Meaning: " << meaning << '\n';
+    }
+
+    bool send(fcitx::LotusEngine& engine, const fcitx::InputMethodEntry& entry, TestInputContext& context, fcitx::KeySym symbol) {
+        fcitx::KeyEvent event(&context, fcitx::Key(symbol), false);
+        engine.keyEvent(entry, event);
+        if (!event.accepted()) {
+            reportFailure("send emoji navigation key", "key accepted", "key rejected", "the real Emoji-mode key handler did not handle the navigation key");
+            return false;
+        }
+        return true;
+    }
+
+} // namespace
+
+int main() {
+    configureTestPaths("fcitx5-lotus-emoji-history-page-navigation");
+    const auto    historyPath = std::filesystem::path(std::getenv("XDG_CONFIG_HOME")) / "fcitx5/conf/lotus-emoji-history.conf";
+    std::ofstream history(historyPath);
+    const char*   emoji[] = {"😀", "😁", "😂", "😃", "😄", "😅", "😆", "😉", "😊", "😋", "😎", "😍", "😘", "😗", "😙", "😚", "🙂", "🤗"};
+    for (int i = 0; i < 18; ++i)
+        history << "history" << i << '=' << emoji[i] << '\n';
+    history.close();
+
+    TestInstance       testInstance;
+    fcitx::LotusEngine engine(&testInstance.instance);
+    fcitx::RawConfig   config;
+    config.setValueByPath("Mode", "Emoji Picker");
+    engine.setConfig(config);
+    if (engine.config().mode.value() != fcitx::LotusMode::Emoji) {
+        reportFailure("configure Emoji Picker", "mode=Emoji Picker", "configured mode differs", "the test cannot enter the real emoji history mode");
+        return 1;
+    }
+
+    auto context = std::make_unique<TestInputContext>(&testInstance.instance);
+    context->focusIn();
+    fcitx::InputMethodEntry  entry("lotus", "Lotus", "vi", "lotus");
+    fcitx::InputContextEvent focus(context.get(), fcitx::EventType::InputContextFocusIn);
+    engine.activate(entry, focus);
+
+    auto candidates = std::dynamic_pointer_cast<fcitx::CommonCandidateList>(context->inputPanel().candidateList());
+    if (!candidates || candidates->totalSize() != 18 || candidates->pageSize() != 9) {
+        reportFailure("load emoji history fixture", "18 candidates with page size 9",
+                      candidates ? "candidates=" + std::to_string(candidates->totalSize()) + ", page-size=" + std::to_string(candidates->pageSize()) : "no candidate list",
+                      "EmojiLoader::loadHistory did not provide the multi-page fixture to the real emoji mode");
+        return 1;
+    }
+
+    // Enter page two using the production Page_Down path, then move Up from its
+    // first candidate. This must wrap within page two, rather than changing page.
+    if (!send(engine, entry, *context, FcitxKey_Page_Down) || !send(engine, entry, *context, FcitxKey_Up))
+        return 1;
+
+    if (candidates->currentPage() != 1 || candidates->globalCursorIndex() != 17) {
+        reportFailure("wrap Up at first candidate of second emoji-history page", "page=1, global cursor=17",
+                      "page=" + std::to_string(candidates->currentPage()) + ", global cursor=" + std::to_string(candidates->globalCursorIndex()),
+                      "emoji candidate navigation crossed pages instead of wrapping within the current page");
+        return 1;
+    }
+    return 0;
+}

--- a/test/modifier-key-bypasses-surrounding-text.cpp
+++ b/test/modifier-key-bypasses-surrounding-text.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "lotus-engine.h"
+#include "test-input-context.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+
+    void reportFailure(const std::string& step, const std::string& expected, const std::string& actual, const std::string& meaning) {
+        std::cerr << "Step: " << step << '\n';
+        std::cerr << "Expected: " << expected << '\n';
+        std::cerr << "Actual: " << actual << '\n';
+        std::cerr << "Meaning: " << meaning << '\n';
+    }
+
+} // namespace
+
+int main() {
+    configureTestPaths("fcitx5-lotus-modifier-key-bypasses-surrounding-text");
+    TestInstance       testInstance;
+    fcitx::LotusEngine engine(&testInstance.instance);
+    fcitx::RawConfig   config;
+    config.setValueByPath("Mode", "Surrounding Text");
+    config.setValueByPath("InputMethod", "Telex");
+    engine.setConfig(config);
+    if (engine.config().mode.value() != fcitx::LotusMode::SurroundingText || engine.config().inputMethod.value() != "Telex") {
+        reportFailure("configure Surrounding Text/Telex", "mode=SurroundingText, input method=Telex", "configured mode or input method differs",
+                      "the raw Fcitx configuration values did not serialize to Surrounding Text Telex behavior");
+        return 1;
+    }
+
+    auto context = std::make_unique<TestInputContext>(&testInstance.instance);
+    context->setCapabilityFlags(fcitx::CapabilityFlag::SurroundingText);
+    context->focusIn();
+    fcitx::InputMethodEntry  entry("lotus", "Lotus", "vi", "lotus");
+    fcitx::InputContextEvent focus(context.get(), fcitx::EventType::InputContextFocusIn);
+    engine.activate(entry, focus);
+    context->surroundingText().setText("abcdef", 2, 5);
+    context->updateSurroundingText();
+    context->resetPreeditUpdateCount();
+
+    fcitx::KeyEvent event(context.get(), fcitx::Key(FcitxKey_Control_L), false);
+    engine.keyEvent(entry, event);
+    if (event.accepted() || !context->deletes().empty() || !context->commits().empty() || !context->forwarded().empty()) {
+        reportFailure("send Control_L press with selected surrounding text", "accepted=false, deletes=0, commits=0, forwarded=0",
+                      "accepted=" + std::to_string(event.accepted()) + ", deletes=" + std::to_string(context->deletes().size()) +
+                          ", commits=" + std::to_string(context->commits().size()) + ", forwarded=" + std::to_string(context->forwarded().size()),
+                      "a modifier-only key must not enter surrounding-text processing");
+        return 1;
+    }
+
+    return 0;
+}

--- a/test/numeric-macro-case-preservation.cpp
+++ b/test/numeric-macro-case-preservation.cpp
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "bamboo-core.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <unistd.h>
+
+namespace {
+
+    void reportFailure(const std::string& step, const std::string& expected, const std::string& actual, const std::string& meaning) {
+        std::cerr << "Step: " << step << '\n';
+        std::cerr << "Expected: " << expected << '\n';
+        std::cerr << "Actual: " << actual << '\n';
+        std::cerr << "Meaning: " << meaning << '\n';
+    }
+
+    class Handle {
+      public:
+        explicit Handle(uintptr_t value = 0) : value_(value) {}
+        ~Handle() {
+            if (value_ != 0)
+                DeleteObject(value_);
+        }
+
+        Handle(const Handle&)              = delete;
+        Handle&   operator=(const Handle&) = delete;
+
+        uintptr_t get() const {
+            return value_;
+        }
+
+        explicit operator bool() const {
+            return value_ != 0;
+        }
+
+      private:
+        uintptr_t value_;
+    };
+
+    bool processKey(uintptr_t engine, uint32_t key, const char* name) {
+        if (!EngineProcessKeyEvent(engine, key, 0)) {
+            reportFailure("process key " + std::string(name), "key event accepted", "key event rejected", "the production Bamboo engine did not retain the numeric macro trigger");
+            return false;
+        }
+        return true;
+    }
+
+} // namespace
+
+int main() {
+    char      dictionaryPath[] = "/tmp/fcitx5-lotus-numeric-macro-XXXXXX";
+    const int dictionaryFd     = mkstemp(dictionaryPath);
+    if (dictionaryFd < 0) {
+        reportFailure("create empty temporary dictionary", "mkstemp succeeds", std::strerror(errno), "the test cannot construct a production dictionary handle");
+        return 1;
+    }
+
+    Handle dictionary(NewDictionary(static_cast<uintptr_t>(dictionaryFd)));
+    unlink(dictionaryPath);
+    if (!dictionary) {
+        reportFailure("create dictionary handle", "non-zero handle", "zero handle", "NewDictionary rejected the empty temporary dictionary");
+        return 1;
+    }
+
+    char   key[]             = "123";
+    char   value[]           = "Mixed Case";
+    char*  macroDefinition[] = {key, value, nullptr};
+    Handle macroTable(NewMacroTable(macroDefinition));
+    if (!macroTable) {
+        reportFailure("create macro table handle", "non-zero handle", "zero handle", "NewMacroTable rejected the numeric macro definition");
+        return 1;
+    }
+
+    Handle engine(NewEngine("Telex", dictionary.get(), macroTable.get()));
+    if (!engine) {
+        reportFailure("create Telex engine handle", "non-zero handle", "zero handle", "NewEngine rejected valid production dependency handles");
+        return 1;
+    }
+
+    FcitxBambooEngineOption option{};
+    option.autoNonVnRestore = true;
+    option.ddFreeStyle      = true;
+    option.macroEnabled     = true;
+    // Keep auto-capitalization enabled: regression #370 altered the expansion's
+    // original letter case when the macro key consisted solely of digits.
+    option.autoCapitalizeMacro = true;
+    option.spellCheckWithDicts = true;
+    option.outputCharset       = "Unicode";
+    option.modernStyle         = false;
+    option.freeMarking         = false;
+    option.w2u                 = 0;
+    option.bracketTransform    = 0;
+    option.timeFormat          = "%H:%M";
+    option.dateFormat          = "%d/%m/%Y";
+    EngineSetOption(engine.get(), &option);
+
+    // Tab terminates the numeric key sequence and triggers macro expansion in Bamboo core.
+    if (!processKey(engine.get(), '1', "1") || !processKey(engine.get(), '2', "2") || !processKey(engine.get(), '3', "3") || !processKey(engine.get(), 0xff09, "Tab"))
+        return 1;
+
+    std::unique_ptr<char, decltype(&std::free)> commit(EnginePullCommit(engine.get()), &std::free);
+    const std::string                           actual = commit ? commit.get() : "<null>";
+    if (actual != "Mixed Case") {
+        reportFailure("verify numeric macro case preservation", "Mixed Case", actual, "auto-capitalization must not change a numeric-only macro expansion's mixed case");
+        return 1;
+    }
+    return 0;
+}

--- a/test/preedit-lifecycle.cpp
+++ b/test/preedit-lifecycle.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file preedit-lifecycle.cpp
+ * @brief Headless integration test for client-side preedit lifecycle & focus transitions.
+ *
+ * Architectural Contract:
+ * In Fcitx5, client applications supporting inline preedit (`CapabilityFlag::Preedit`)
+ * render uncommitted composition directly inside their text widgets (e.g. Qt, GTK, Electron).
+ *
+ * When an input context undergoes focus or lifecycle transitions:
+ * 1. Active Composition: Typing keys (e.g. 'a', 's' in Telex) must update the client
+ *    preedit text to "á" without prematurely committing text to the document.
+ * 2. Focus Loss (`FocusOut` / Deactivate): When the user switches windows or clicks outside,
+ *    the active preedit composition MUST be committed to the document exactly once,
+ *    and the client preedit buffer must be cleared.
+ * 3. Focus Regain (`FocusIn` / Activate): When returning focus to the application, the
+ *    preedit buffer must remain clean. No stale ghost text or duplicate commits should occur.
+ *
+ * This test uses `TestInputContext` and `TestInstance` to deterministically verify these
+ * state transitions without a running X11/Wayland desktop session.
+ */
+
+#include "lotus-engine.h"
+#include "test-input-context.h"
+
+#include <fcitx-utils/utf8.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+    // Helper to log explicit assertion failures with step, expected, actual, and business meaning.
+    void reportFailure(const std::string& step, const std::string& expected, const std::string& actual, const std::string& meaning) {
+        std::cerr << "Step: " << step << '\n';
+        std::cerr << "Expected: " << expected << '\n';
+        std::cerr << "Actual: " << actual << '\n';
+        std::cerr << "Meaning: " << meaning << '\n';
+    }
+
+} // namespace
+
+int main() {
+    // Step 0: Sandbox filesystem paths to /tmp/fcitx5-lotus-preedit-lifecycle
+    configureTestPaths("fcitx5-lotus-preedit-lifecycle");
+    TestInstance       testInstance;
+    fcitx::LotusEngine engine(&testInstance.instance);
+
+    // Step 1: Configure Lotus in Preedit mode with Telex input method
+    fcitx::RawConfig config;
+    config.setValueByPath("Mode", "Preedit");
+    config.setValueByPath("InputMethod", "Telex");
+    engine.setConfig(config);
+    if (engine.config().mode.value() != fcitx::LotusMode::Preedit || engine.config().inputMethod.value() != "Telex") {
+        reportFailure("configure Preedit/Telex", "mode=Preedit, input method=Telex", "configured mode or input method differs",
+                      "the lifecycle test cannot exercise client preedit behavior");
+        return 1;
+    }
+
+    // Step 2: Initialize mock InputContext with Preedit capability (emulating inline client app like GTK/Qt)
+    auto context = std::make_unique<TestInputContext>(&testInstance.instance);
+    context->setCapabilityFlags(fcitx::CapabilityFlag::Preedit);
+    context->focusIn();
+    fcitx::InputMethodEntry  entry("lotus", "Lotus", "vi", "lotus");
+
+    fcitx::InputContextEvent in(context.get(), fcitx::EventType::InputContextFocusIn);
+    engine.activate(entry, in);
+    context->resetPreeditUpdateCount();
+
+    // Step 3: Type Telex keys 'a' followed by 's' -> should compose Vietnamese character "á"
+    for (auto sym : {FcitxKey_a, FcitxKey_s}) {
+        fcitx::KeyEvent event(context.get(), fcitx::Key(sym), false);
+        engine.keyEvent(entry, event);
+        if (!event.accepted()) {
+            reportFailure("type Telex key", "key event accepted", "key " + std::to_string(sym) + " was not accepted", "Lotus did not process the Telex input");
+            return 1;
+        }
+    }
+
+    // Step 4: Verify client preedit state during active composition
+    // - Client preedit must hold "á" (valid UTF-8, 2 bytes, cursor at end).
+    // - Server preedit (candidate window) must be empty.
+    // - Commits must be 0 (composition is still active, not yet committed).
+    // - updatePreedit() must have been called twice (once for 'a', once for 's').
+    const auto& clientPreedit = context->inputPanel().clientPreedit();
+    const auto& serverPreedit = context->inputPanel().preedit();
+    if (clientPreedit.toString() != "á" || !fcitx::utf8::validate(clientPreedit.toString()) || clientPreedit.cursor() != 2 || !context->commits().empty() ||
+        !serverPreedit.toString().empty() || context->preeditUpdates() != 2) {
+        reportFailure("type a then s in Preedit/Telex", "client preedit=á (valid UTF-8, cursor=2), server preedit empty, commits=0, updatePreedit count=2",
+                      "client preedit=" + clientPreedit.toString() + ", cursor=" + std::to_string(clientPreedit.cursor()) + ", server preedit=" + serverPreedit.toString() +
+                          ", commits=" + std::to_string(context->commits().size()) + ", updatePreedit count=" + std::to_string(context->preeditUpdates()),
+                      "Preedit mode must expose the composed Telex result through client preedit without committing it");
+        return 1;
+    }
+
+    // Step 5: Emulate FocusOut (user switches windows or clicks outside)
+    // - Active preedit "á" must be committed to the client application exactly once.
+    const std::vector<std::string> expectedCommits{"á"};
+    context->focusOut();
+    if (context->commits() != expectedCommits) {
+        reportFailure("focus out with active client preedit", "commits=[á]",
+                      "commit count=" + std::to_string(context->commits().size()) + (context->commits().empty() ? "" : ", first commit=" + context->commits().front()),
+                      "Fcitx must commit the active client preedit exactly once when the client does not handle unfocus commits");
+        return 1;
+    }
+
+    // Step 6: Emulate deactivation on FocusOut
+    // - Engine must clear client preedit buffer with one additional update call (total updates = 3).
+    fcitx::InputContextEvent out(context.get(), fcitx::EventType::InputContextFocusOut);
+    engine.deactivate(entry, out);
+    if (!context->inputPanel().clientPreedit().toString().empty() || context->preeditUpdates() != 3) {
+        reportFailure("deactivate on focus out", "client preedit empty, updatePreedit count=3",
+                      "client preedit=" + context->inputPanel().clientPreedit().toString() + ", updatePreedit count=" + std::to_string(context->preeditUpdates()),
+                      "focus-out deactivation must clear the client preedit with one additional update");
+        return 1;
+    }
+
+    // Step 7: Emulate FocusIn & reactivation (user refocuses the application)
+    // - Engine reactivation must keep the preedit buffer empty.
+    // - No duplicate commits or lingering ghost characters should be emitted.
+    context->focusIn();
+    fcitx::InputContextEvent reactivate(context.get(), fcitx::EventType::InputContextFocusIn);
+    engine.activate(entry, reactivate);
+    if (!context->inputPanel().clientPreedit().toString().empty() || context->commits() != expectedCommits) {
+        reportFailure("reactivate after focus out", "client preedit empty, commits=[á]",
+                      "client preedit=" + context->inputPanel().clientPreedit().toString() + ", commit count=" + std::to_string(context->commits().size()),
+                      "reactivation must preserve the cleared preedit without committing stale text");
+        return 1;
+    }
+
+    return 0; // All lifecycle invariants verified successfully
+}

--- a/test/preedit-smoke-client.cpp
+++ b/test/preedit-smoke-client.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "lotus-engine.h"
+#include "test-input-context.h"
+
+#include <fcitx-utils/utf8.h>
+#include <iostream>
+
+int main() {
+    configureTestPaths("fcitx5-lotus-preedit-client");
+    TestInstance       testInstance;
+    fcitx::LotusEngine engine(&testInstance.instance);
+    fcitx::RawConfig   config;
+    config.setValueByPath("Mode", "Preedit");
+    config.setValueByPath("InputMethod", "Telex");
+    engine.setConfig(config);
+    if (engine.config().mode.value() != fcitx::LotusMode::Preedit || engine.config().inputMethod.value() != "Telex") {
+        std::cerr << "failed to configure Preedit/Telex\n";
+        return 1;
+    }
+    auto context = std::make_unique<TestInputContext>(&testInstance.instance);
+    context->setCapabilityFlags(fcitx::CapabilityFlag::Preedit);
+    context->focusIn();
+    fcitx::InputMethodEntry  entry("lotus", "Lotus", "vi", "lotus");
+    fcitx::InputContextEvent focus(context.get(), fcitx::EventType::InputContextFocusIn);
+    engine.activate(entry, focus);
+    context->resetPreeditUpdateCount();
+
+    // Bamboo Telex processes a then s as U+00E1 LATIN SMALL LETTER A WITH ACUTE.
+    for (auto sym : {FcitxKey_a, FcitxKey_s}) {
+        fcitx::KeyEvent event(context.get(), fcitx::Key(sym), false);
+        engine.keyEvent(entry, event);
+        if (!event.accepted()) {
+            std::cerr << "key " << sym << " accepted=" << event.accepted() << '\n';
+            return 1;
+        }
+    }
+    const auto& preedit = context->inputPanel().clientPreedit();
+    if (preedit.toString() != "á" || !fcitx::utf8::validate(preedit.toString()) || preedit.cursor() != 2 || context->preeditUpdates() != 2 || !context->commits().empty() ||
+        !context->inputPanel().preedit().toString().empty()) {
+        std::cerr << "client='" << preedit.toString() << "' server='" << context->inputPanel().preedit().toString() << "' cursor=" << preedit.cursor()
+                  << " updates=" << context->preeditUpdates() << " commits=" << context->commits().size() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/test/preedit-smoke-server.cpp
+++ b/test/preedit-smoke-server.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "lotus-engine.h"
+#include "test-input-context.h"
+
+#include <fcitx-utils/utf8.h>
+#include <iostream>
+
+int main() {
+    configureTestPaths("fcitx5-lotus-preedit-server");
+    TestInstance       testInstance;
+    fcitx::LotusEngine engine(&testInstance.instance);
+    fcitx::RawConfig   config;
+    config.setValueByPath("Mode", "Preedit");
+    config.setValueByPath("InputMethod", "Telex");
+    engine.setConfig(config);
+    if (engine.config().mode.value() != fcitx::LotusMode::Preedit || engine.config().inputMethod.value() != "Telex") {
+        std::cerr << "failed to configure Preedit/Telex\n";
+        return 1;
+    }
+    auto context = std::make_unique<TestInputContext>(&testInstance.instance);
+    context->focusIn();
+    fcitx::InputMethodEntry  entry("lotus", "Lotus", "vi", "lotus");
+    fcitx::InputContextEvent focus(context.get(), fcitx::EventType::InputContextFocusIn);
+    engine.activate(entry, focus);
+    context->resetPreeditUpdateCount();
+
+    for (auto sym : {FcitxKey_a, FcitxKey_s}) {
+        fcitx::KeyEvent event(context.get(), fcitx::Key(sym), false);
+        engine.keyEvent(entry, event);
+        if (!event.accepted()) {
+            std::cerr << "key " << sym << " accepted=" << event.accepted() << '\n';
+            return 1;
+        }
+    }
+    const auto& preedit = context->inputPanel().preedit();
+    if (preedit.toString() != "á" || !fcitx::utf8::validate(preedit.toString()) || preedit.cursor() != 2 || context->preeditUpdates() != 0 || !context->commits().empty() ||
+        !context->inputPanel().clientPreedit().toString().empty()) {
+        std::cerr << "client='" << context->inputPanel().clientPreedit().toString() << "' server='" << preedit.toString() << "' cursor=" << preedit.cursor()
+                  << " updates=" << context->preeditUpdates() << " commits=" << context->commits().size() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/test/smooth-buffered-key-replay.cpp
+++ b/test/smooth-buffered-key-replay.cpp
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "lotus-engine.h"
+#include "lotus-utils.h"
+#include "test-input-context.h"
+
+#include <cerrno>
+#include <cstddef>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+namespace {
+
+    void reportFailure(const std::string& step, const std::string& expected, const std::string& actual, const std::string& meaning) {
+        std::cerr << "Step: " << step << '\n';
+        std::cerr << "Expected: " << expected << '\n';
+        std::cerr << "Actual: " << actual << '\n';
+        std::cerr << "Meaning: " << meaning << '\n';
+    }
+
+    class BackspaceListener {
+      public:
+        BackspaceListener() {
+            fd_ = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+            if (fd_ < 0) {
+                fail("socket");
+                return;
+            }
+            sockaddr_un address{};
+            address.sun_family    = AF_UNIX;
+            const auto socketPath = buildSocketPath("kb_socket");
+            address.sun_path[0]   = '\0';
+            std::memcpy(&address.sun_path[1], socketPath.data(), socketPath.size());
+            const auto length = static_cast<socklen_t>(offsetof(sockaddr_un, sun_path) + socketPath.size() + 1);
+            if (bind(fd_, reinterpret_cast<const sockaddr*>(&address), length) < 0 || listen(fd_, 1) < 0) {
+                fail("bind/listen");
+            }
+        }
+
+        ~BackspaceListener() {
+            if (client_ >= 0)
+                close(client_);
+            if (fd_ >= 0)
+                close(fd_);
+        }
+
+        bool receive(int& count, const char* meaning, const char* requestTimeoutExpected = "request within 2000 ms") {
+            if (client_ < 0) {
+                if (fd_ < 0) {
+                    reportFailure("wait for replacement socket connection", "valid listener descriptor", "listener descriptor is invalid", meaning);
+                    return false;
+                }
+                pollfd     pollfd{fd_, POLLIN, 0};
+                const auto pollResult = poll(&pollfd, 1, 2000);
+                if (pollResult == 0) {
+                    reportFailure("wait for replacement socket connection", "connection request within 2000 ms", "poll timed out", meaning);
+                    return false;
+                }
+                if (pollResult < 0) {
+                    reportFailure("wait for replacement socket connection", "poll succeeds", "poll failed: " + std::string(std::strerror(errno)), meaning);
+                    return false;
+                }
+                if (!(pollfd.revents & POLLIN)) {
+                    reportFailure("wait for replacement socket connection", "POLLIN revents", "revents=" + std::to_string(pollfd.revents), meaning);
+                    return false;
+                }
+                client_ = accept(fd_, nullptr, nullptr);
+                if (client_ < 0) {
+                    reportFailure("accept replacement socket connection", "accept succeeds", "accept failed: " + std::string(std::strerror(errno)), meaning);
+                    return false;
+                }
+            }
+            pollfd     pollfd{client_, POLLIN, 0};
+            const auto pollResult = poll(&pollfd, 1, 2000);
+            if (pollResult == 0) {
+                reportFailure("wait for replacement request", requestTimeoutExpected, "poll timed out", meaning);
+                return false;
+            }
+            if (pollResult < 0) {
+                reportFailure("wait for replacement request", "poll succeeds", "poll failed: " + std::string(std::strerror(errno)), meaning);
+                return false;
+            }
+            if (!(pollfd.revents & POLLIN)) {
+                reportFailure("wait for replacement request", "POLLIN revents", "revents=" + std::to_string(pollfd.revents), meaning);
+                return false;
+            }
+            const auto received = recv(client_, &count, sizeof(count), 0);
+            if (received < 0) {
+                reportFailure("receive replacement request", std::to_string(sizeof(count)) + " bytes", "recv failed: " + std::string(std::strerror(errno)), meaning);
+                return false;
+            }
+            if (received != sizeof(count)) {
+                reportFailure("receive replacement request", std::to_string(sizeof(count)) + " bytes", "recv returned " + std::to_string(received) + " bytes", meaning);
+                return false;
+            }
+            return true;
+        }
+
+        bool valid() const {
+            return fd_ >= 0;
+        }
+
+      private:
+        void fail(const char* operation) {
+            reportFailure(std::string(operation) + " replacement socket", "operation succeeds", std::string(operation) + " failed: " + std::strerror(errno),
+                          "the test cannot observe Smooth replacement requests");
+            close(fd_);
+            fd_ = -1;
+        }
+
+        int fd_     = -1;
+        int client_ = -1;
+    };
+
+    bool send(fcitx::LotusEngine& engine, const fcitx::InputMethodEntry& entry, TestInputContext& context, fcitx::KeySym symbol, bool requireAccepted) {
+        fcitx::KeyEvent event(&context, fcitx::Key(symbol), false);
+        engine.keyEvent(entry, event);
+        if (event.accepted() != requireAccepted) {
+            reportFailure("process key " + std::to_string(symbol), "accepted=" + std::to_string(requireAccepted),
+                          "accepted=" + std::to_string(event.accepted()) + ", commits=" + std::to_string(context.commits().size()),
+                          "Smooth buffered-key handling accepted or rejected the key unexpectedly");
+            return false;
+        }
+        return true;
+    }
+
+} // namespace
+
+int main() {
+    configureTestPaths("fcitx5-lotus-smooth-buffered-key-replay");
+    TestInstance       testInstance;
+    fcitx::LotusEngine engine(&testInstance.instance);
+    fcitx::RawConfig   config;
+    config.setValueByPath("Mode", "Uinput (Smooth)");
+    config.setValueByPath("InputMethod", "Telex");
+    engine.setConfig(config);
+    if (engine.config().mode.value() != fcitx::LotusMode::Smooth || engine.config().inputMethod.value() != "Telex") {
+        reportFailure("configure Smooth/Telex", "mode=Smooth, input method=Telex", "configured mode or input method differs",
+                      "the replay test cannot exercise Smooth Telex behavior");
+        return 1;
+    }
+
+    BackspaceListener listener;
+    if (!listener.valid())
+        return 1;
+    auto context = std::make_unique<TestInputContext>(&testInstance.instance);
+    context->focusIn();
+    fcitx::InputMethodEntry  entry("lotus", "Lotus", "vi", "lotus");
+    fcitx::InputContextEvent focus(context.get(), fcitx::EventType::InputContextFocusIn);
+    engine.activate(entry, focus);
+    context->resetPreeditUpdateCount();
+
+    // Telex a, s changes the real Bamboo preedit a -> á. Smooth mode replaces
+    // the old character through the kb_socket transport.
+    if (!send(engine, entry, *context, FcitxKey_a, false) || !send(engine, entry, *context, FcitxKey_s, true))
+        return 1;
+    int backspaces = 0;
+    if (!listener.receive(backspaces, "the initial Telex replacement request did not arrive"))
+        return 1;
+    if (backspaces <= 0) {
+        reportFailure("receive initial replacement count", "backspace count > 0", "backspace count=" + std::to_string(backspaces),
+                      "the Telex replacement did not request deletion of the previous character");
+        return 1;
+    }
+
+    if (!send(engine, entry, *context, FcitxKey_x, true) || !context->commits().empty()) {
+        reportFailure("buffer key x before deletion completes", "no immediate commits", "commits=" + std::to_string(context->commits().size()),
+                      "buffered key x was emitted before the first replacement completed");
+        return 1;
+    }
+    for (int i = 0; i < backspaces; ++i) {
+        if (!send(engine, entry, *context, FcitxKey_BackSpace, i + 1 == backspaces))
+            return 1;
+    }
+
+    int replayBackspaces = 0;
+    if (!listener.receive(replayBackspaces, "buffered key was not replayed after deletion", "buffered x replay starts another replacement request within 2000 ms"))
+        return 1;
+    if (replayBackspaces <= 0) {
+        reportFailure("receive replay replacement count", "backspace count > 0", "backspace count=" + std::to_string(replayBackspaces),
+                      "buffered key x did not start another replacement after deletion");
+        return 1;
+    }
+    for (int i = 0; i < replayBackspaces; ++i) {
+        if (!send(engine, entry, *context, FcitxKey_BackSpace, i + 1 == replayBackspaces))
+            return 1;
+    }
+
+    const std::vector<std::string> expected{"á", "ã"};
+    if (context->commits() != expected) {
+        std::string actual = "commits=";
+        for (const auto& commit : context->commits())
+            actual += "['" + commit + "']";
+        const auto meaning = "the buffered key replay did not produce the expected final commits; "
+                             "first-backspaces=" +
+            std::to_string(backspaces) + ", replay-backspaces=" + std::to_string(replayBackspaces);
+        reportFailure("verify final replay commits", "commits=['á']['ã']", actual, meaning);
+        return 1;
+    }
+    return 0;
+}

--- a/test/test-emoji-backspace.cpp
+++ b/test/test-emoji-backspace.cpp
@@ -12,12 +12,6 @@
 //   - the buffer is truncated to the expected substring, and
 //   - the result is well-formed UTF-8 (using fcitx::utf8::validate).
 //
-// Build & run (no CMake integration, same pattern as scripts/test/):
-//   g++ -std=c++17 test-emoji-backspace.cpp ../src/lotus-utils.cpp \
-//       -I../src $(pkg-config --cflags --libs fcitx5-core fcitx5-utils) \
-//       -o test_emoji_backspace
-//   ./test_emoji_backspace
-
 #include "lotus-utils.h"
 
 #include <cstdio>

--- a/test/test-input-context.h
+++ b/test/test-input-context.h
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fcitx/addonmanager.h>
+#include <fcitx/inputcontext.h>
+#include <fcitx/inputcontextmanager.h>
+#include <fcitx/inputpanel.h>
+#include <fcitx/instance.h>
+#include <fcitx/text.h>
+
+/**
+ * @brief Headless Mock InputContext for Fcitx5-Lotus Integration Testing.
+ *
+ * Architecture & Rationale:
+ * Fcitx5 input method engines interact with client applications (text editors,
+ * browsers, terminals) through an abstract `fcitx::InputContext` interface. In a
+ * live desktop environment, concrete implementations (like X11, Wayland, or D-Bus
+ * frontends) handle IPC and render UI.
+ *
+ * In headless integration tests, we need to verify engine behavior (commits,
+ * backspaces, forwarded keys, preedit updates) without running a display server
+ * (X11/Wayland) or D-Bus daemon. `TestInputContext` subclasses `fcitx::InputContext`
+ * directly, intercepting all engine output callbacks and recording them into
+ * in-memory vectors for synchronous, deterministic assertions.
+ *
+ * Example — Writing a new integration test:
+ * @code
+ * int main() {
+ *     // 1. Sandbox filesystem paths to /tmp/fcitx5-lotus-my-test
+ *     configureTestPaths("fcitx5-lotus-my-test");
+ *
+ *     // 2. Initialize headless Fcitx instance and Lotus engine
+ *     TestInstance testInstance;
+ *     fcitx::LotusEngine engine(&testInstance.instance);
+ *
+ *     // 3. Set engine mode and input method
+ *     fcitx::RawConfig config;
+ *     config.setValueByPath("Mode", "Preedit"); // or "Surrounding", "Smooth", "Off"
+ *     config.setValueByPath("InputMethod", "Telex");
+ *     engine.setConfig(config);
+ *
+ *     // 4. Create mock context with client capabilities and activate
+ *     auto context = std::make_unique<TestInputContext>(&testInstance.instance);
+ *     context->setCapabilityFlags(fcitx::CapabilityFlag::Preedit);
+ *     context->focusIn();
+ *     fcitx::InputMethodEntry entry("lotus", "Lotus", "vi", "lotus");
+ *     fcitx::InputContextEvent in(context.get(), fcitx::EventType::InputContextFocusIn);
+ *     engine.activate(entry, in);
+ *
+ *     // 5. Send keystrokes to the engine
+ *     fcitx::KeyEvent event(context.get(), fcitx::Key(FcitxKey_a), false);
+ *     engine.keyEvent(entry, event);
+ *
+ *     // 6. Assert on recorded outputs
+ *     // - Commits:        context->commits()
+ *     // - Deletions:      context->deletes()
+ *     // - Forwarded keys: context->forwarded()
+ *     // - Client preedit: context->inputPanel().clientPreedit().toString()
+ *     if (!event.accepted() || context->inputPanel().clientPreedit().toString() != "a") {
+ *         return 1; // Test failed
+ *     }
+ *     return 0; // Test passed
+ * }
+ * @endcode
+ *
+ * CMake Registration (test/CMakeLists.txt):
+ * @code
+ * add_lotus_headless_test(my_test my-test.cpp "integration;myfeature")
+ * @endcode
+ */
+class TestInputContext final : public fcitx::InputContext {
+  public:
+    explicit TestInputContext(fcitx::Instance* instance) : InputContext(instance->inputContextManager(), "test") {
+        // Fcitx5 lifecycle contract: notifies the InputContextManager that
+        // this context is initialized and ready to receive events.
+        created();
+    }
+
+    ~TestInputContext() override {
+        // Fcitx5 lifecycle contract: detaches context and invalidates event slots.
+        destroy();
+    }
+
+    const char* frontend() const override {
+        return "test";
+    }
+
+    // Called by the engine when text is committed to the client application.
+    void commitStringImpl(const std::string& text) override {
+        commits_.push_back(text);
+    }
+
+    // Called when the engine requests surrounding text deletion (e.g. backspacing
+    // prior characters during composition or word replacement).
+    void deleteSurroundingTextImpl(int offset, unsigned int size) override {
+        deletes_.emplace_back(offset, size);
+    }
+
+    // Called when a key event is not consumed by the engine and forwarded
+    // back to the client application (passthrough mode).
+    void forwardKeyImpl(const fcitx::ForwardKeyEvent& event) override {
+        forwarded_.push_back(event);
+    }
+
+    // Called when inline preedit text or server candidate window changes.
+    void updatePreeditImpl() override {
+        ++preeditUpdates_;
+    }
+
+    // Verification helpers: inspect recorded engine actions
+    void resetPreeditUpdateCount() {
+        preeditUpdates_ = 0;
+    }
+    unsigned int preeditUpdates() const {
+        return preeditUpdates_;
+    }
+    const std::vector<std::string>& commits() const {
+        return commits_;
+    }
+    const auto& deletes() const {
+        return deletes_;
+    }
+    const auto& forwarded() const {
+        return forwarded_;
+    }
+
+  private:
+    std::vector<std::string>                  commits_;
+    std::vector<std::pair<int, unsigned int>> deletes_;
+    std::vector<fcitx::ForwardKeyEvent>       forwarded_;
+    unsigned int                              preeditUpdates_ = 0;
+};
+
+/**
+ * @brief Sandboxes environment paths to isolate tests from host user configuration.
+ *
+ * Fcitx5 engines and Bamboo read/write user configuration, dictionaries, and cache
+ * under $HOME, $XDG_CONFIG_HOME, $XDG_DATA_HOME, and $XDG_CACHE_HOME.
+ * Calling `configureTestPaths` redirects all these paths to an ephemeral subdirectory
+ * in the system temporary folder (`/tmp/<name>`).
+ *
+ * Guarantees:
+ * 1. Clean slate: Previous runs or local user configs will not contaminate test results.
+ * 2. Host safety: Tests will NEVER overwrite developer's personal fcitx5 settings.
+ * 3. Parallel-safe: Each test target passes a unique test name for isolated folders.
+ */
+inline void configureTestPaths(const char* name) {
+    const auto root = std::filesystem::temp_directory_path() / name;
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "config/fcitx5/conf");
+    std::filesystem::create_directories(root / "data");
+    std::filesystem::create_directories(root / "cache");
+    setenv("HOME", root.c_str(), 1);
+    setenv("XDG_CONFIG_HOME", (root / "config").c_str(), 1);
+    setenv("XDG_DATA_HOME", (root / "data").c_str(), 1);
+    setenv("XDG_CACHE_HOME", (root / "cache").c_str(), 1);
+}
+
+/**
+ * @brief Headless Fcitx5 instance environment isolator.
+ *
+ * Instantiates a minimal, headless `fcitx::Instance` with:
+ * - `--disable=all`: disables loading external modules (UI, D-Bus, Wayland/X11 frontends),
+ *   allowing the instance to initialize in pure headless/CI containers without hanging.
+ * - `registerDefaultLoader(nullptr)`: prevents dynamic plugin loader from scanning
+ *   system directories (`/usr/lib/fcitx5`) for host-installed addons.
+ */
+struct TestInstance {
+    TestInstance() : instance(2, argv) {
+        instance.addonManager().registerDefaultLoader(nullptr);
+        instance.initialize();
+    }
+    char            program[64]    = "lotus-headless-test";
+    char            disableAll[16] = "--disable=all";
+    char*           argv[3]        = {program, disableAll, nullptr};
+    fcitx::Instance instance;
+};


### PR DESCRIPTION
Add a headless CTest harness for exercising Lotus engine behavior without a desktop session.

**No runtime behavior is changed by this PR, the changes are limited to test infrastructure, regression tests, and CI coverage.**

The tests cover preedit lifecycle, buffered key replay, surrounding text, emoji handling, and numeric macros.

## Regression validation

Each regression test was run against the corresponding historical revision before and after the original fix.

| Regression | Before fix | After fix |
| --- | --- | --- |
| #56 Smooth buffered-key replay | [fails (CI #231)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33924538387) | [passes (CI #232)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33924539089) |
| #185 Preedit reset / focus-out | [fails (CI #219)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33921727359) | [passes (CI #221)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33923822145) |
| #269 Emoji page navigation | [fails (CI #224)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33924369757) | [passes (CI #223)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33924369323) |
| #324 Modifier-only surrounding text | [fails (CI #226)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33924412554) | [passes (CI #225)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33924412515) |
| #370 Numeric macro case preservation | [fails (CI #240)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33932745944) | [passes (CI #241)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33932746331) |
| #375 UTF-8 backspace | [fails (CI #234)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33925692538) | [passes (CI #235)](https://github.com/naoNao89/fcitx5-lotus/actions/runs/33925692705) |

The base and fixed proof branches share the same harness and regression test.
The fixed branches apply the corresponding historical production fixes.
