### PR TITLE
fix: macro keys defined in upper case never match

### DIFF
--- a/bamboo/bamboo-c.go
+++ b/bamboo/bamboo-c.go
@@ -233,7 +233,7 @@ func NewMacroTable(definition **C.char) uintptr {
 	maxEntries := 1<<20 - 1
 	i := 0
 	for i < maxEntries && def[i] != nil {
-		table.mTable[C.GoString(def[i])] = C.GoString(def[i+1])
+		table.Set(C.GoString(def[i]), C.GoString(def[i+1]))
 		i += 2
 	}
 

--- a/bamboo/fcitxbambooengine_test.go
+++ b/bamboo/fcitxbambooengine_test.go
@@ -393,3 +393,31 @@ func TestIsValidState(t *testing.T) {
 		}
 	}
 }
+
+func TestMacroDefinedWithUpperCaseKey(t *testing.T) {
+	// Macro keys are looked up case-insensitively, so a key entered in capitals
+	// in the settings UI must trigger just like a lower-case one.
+	e := newTestEngine(nil, false)
+	e.macroEnabled = true
+	e.autoCapitalizeMacro = true
+	e.macroTable = &MacroTable{}
+	e.macroTable.Set("VN", "Việt Nam")
+
+	typeKeys(e, "VN")
+	e.preeditProcessKeyEvent(FcitxSpace, 0)
+	if e.commitText != "VIỆT NAM " {
+		t.Errorf("upper-case macro key commit got [%s] expected [VIỆT NAM ]", e.commitText)
+	}
+
+	// The same definition must also fire when typed in lower case.
+	e = newTestEngine(nil, false)
+	e.macroEnabled = true
+	e.macroTable = &MacroTable{}
+	e.macroTable.Set("VN", "Việt Nam")
+
+	typeKeys(e, "vn")
+	e.preeditProcessKeyEvent(FcitxSpace, 0)
+	if e.commitText != "Việt Nam " {
+		t.Errorf("lower-case typing of upper-case macro key commit got [%s] expected [Việt Nam ]", e.commitText)
+	}
+}

--- a/bamboo/macrotable.go
+++ b/bamboo/macrotable.go
@@ -16,6 +16,18 @@ func (e *MacroTable) Empty() bool {
 	return e == nil || len(e.mTable) == 0
 }
 
+// Set stores a macro entry, normalizing the key to lower case so that it can
+// be found again by Get(), which looks the key up case-insensitively.
+func (e *MacroTable) Set(key, value string) {
+	if e == nil || len(key) == 0 {
+		return
+	}
+	if e.mTable == nil {
+		e.mTable = map[string]string{}
+	}
+	e.mTable[strings.ToLower(key)] = value
+}
+
 func (e *MacroTable) Get(key string) (string,bool) {
 	if len(key) == 0 || e.Empty() {
 		return "", false

--- a/bamboo/macrotable_test.go
+++ b/bamboo/macrotable_test.go
@@ -55,3 +55,28 @@ func TestMacroTableDeprecatedHelpers(t *testing.T) {
 		t.Errorf("GetText(VN) got [%s] expected [Việt Nam]", got)
 	}
 }
+
+func TestMacroTableSetIsCaseInsensitive(t *testing.T) {
+	table := &MacroTable{}
+	table.Set("VN", "Việt Nam")
+
+	// A macro defined with an upper-case key must still be reachable, both by
+	// the exact spelling and by the lower-case one. Get() lower-cases the
+	// lookup, so Set() has to normalize the key the same way.
+	for _, key := range []string{"VN", "vn", "Vn"} {
+		if val, ok := table.Get(key); !ok || val != "Việt Nam" {
+			t.Errorf("Set(VN) then Get(%s) got [%s,%v] expected [Việt Nam,true]", key, val, ok)
+		}
+	}
+}
+
+func TestMacroTableSetGuards(t *testing.T) {
+	var nilTable *MacroTable
+	nilTable.Set("vn", "Việt Nam") // must not panic
+
+	table := &MacroTable{}
+	table.Set("", "Việt Nam")
+	if !table.Empty() {
+		t.Errorf("Set(empty key) got [stored] expected [ignored]")
+	}
+}


### PR DESCRIPTION
# Mô tả

Macro gõ tắt được định nghĩa bằng khoá **viết hoa** thì không bao giờ chạy.

Ví dụ, với `lotus-macro-table.conf` chứa:

```
VN=Việt Nam
```

thì gõ `VN` hay `vn` đều không nở ra gì cả, và không có thông báo lỗi nào. Chỉ khoá viết thường (`vn=Việt Nam`) mới hoạt động.

**Nguyên nhân.** `NewMacroTable()` lưu khoá **y nguyên** như trong file cấu hình:

```go
table.mTable[C.GoString(def[i])] = C.GoString(def[i+1])
```

trong khi `MacroTable.Get()` **luôn** hạ khoá về chữ thường trước khi tra:

```go
val, ok := e.mTable[strings.ToLower(key)]
```

Hai đầu không khớp nhau. Vì việc tra khoá luôn hạ chữ thường, mọi khoá được lưu có chứa chữ hoa đều không còn đường nào chạm tới — nó nằm trong bảng như một mục chết. Giao diện cài đặt (`macro_editor.py`) lưu khoá đúng như người dùng gõ (`key_item.text()`) và chỉ chặn khoá có dấu cách hoặc ký tự đặc biệt, nên người dùng hoàn toàn có thể tạo ra một macro chết mà không hề biết.

**Chế độ `CapitalizeMacro` không phải thứ bị hỏng, và PR này không đổi nó.** Tính năng đó hiện chạy đúng: với macro `kg = khô gà`, gõ `kg` ra `khô gà`, gõ `KG` ra `KHÔ GÀ` — cả trước lẫn sau thay đổi này. Phần hỏng nằm ở đầu lưu khoá, độc lập với tuỳ chọn này.

**Vì sao sửa ở đầu lưu chứ không phải đầu tra.** Về nguyên tắc có thể làm hai đầu khớp nhau theo hướng ngược lại — bỏ `strings.ToLower()` trong `Get()`. Nhưng như vậy sẽ phá `CapitalizeMacro`: gõ `KG` sẽ không còn tìm thấy macro `kg` nữa. Chuẩn hoá khoá ngay lúc lưu là hướng duy nhất vá được chỗ lệch mà giữ nguyên hành vi đang đúng.

**Cách sửa.** Thêm `MacroTable.Set()` — chuẩn hoá khoá về chữ thường ngay lúc lưu — và cho `NewMacroTable()` dùng hàm này, để hai đầu của map thống nhất.

Lưu ý về hành vi: hai khoá chỉ khác nhau hoa thường (`VN` và `vn`) nay gộp thành một mục, dòng sau đè dòng trước. Điều này khớp với cách chúng được tra cứu; và trên thực tế không mất gì đang dùng được, vì mục viết hoa vốn đã chết từ trước.

## Loại thay đổi

- [ ] Tính năng mới
- [x] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD

## Liên kết issue

Không có issue tương ứng — lỗi được phát hiện khi đọc code.

## Screenshot (cho UI changes)

Không đổi giao diện.

# Test

Ba bài test mới, đều đã được xác nhận là **thật sự bắt được lỗi**: khi tạm lật ngược bản sửa, `TestMacroDefinedWithUpperCaseKey` đỏ và cho ra `VN ` thay vì `VIỆT NAM `.

- `TestMacroTableSetIsCaseInsensitive` — `Set("VN", …)` rồi `Get("VN"/"vn"/"Vn")` đều phải ra kết quả.
- `TestMacroTableSetGuards` — `Set` trên con trỏ nil không panic; khoá rỗng bị bỏ qua.
- `TestMacroDefinedWithUpperCaseKey` — mức engine: định nghĩa macro khoá `VN`, gõ `VN` + dấu cách ra `VIỆT NAM ` (khi bật tự viết hoa), gõ `vn` + dấu cách ra `Việt Nam `.

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [x] `clang-format` — không áp dụng: PR không đổi file C/C++ nào, chỉ đổi phía Go
- [ ] Build C++ (`cmake .. && make`) — **chưa chạy được**: máy của tôi không có fcitx5 development headers nên không dựng được phần C++. PR không đụng tới code C++; xin nhờ CI xác nhận.
- [x] Test pass (`cd bamboo/ && go test -race ./...`), cùng với `go vet ./...` và `gofmt -l *_test.go` sạch
- [x] Đã rebase với nhánh `dev` mới nhất (5220797)
- [ ] Các CI checks pass:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
