### PR TITLE
fix: guard against invalid cgo handles crashing the process

### DIFF
--- a/bamboo/bamboo-c.go
+++ b/bamboo/bamboo-c.go
@@ -48,7 +48,7 @@ func Init() {
 
 //export EngineProcessKeyEvent
 func EngineProcessKeyEvent(engine uintptr, keyVal, state uint32) bool {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return false
 	}
@@ -57,7 +57,7 @@ func EngineProcessKeyEvent(engine uintptr, keyVal, state uint32) bool {
 
 //export EngineSetRestoreKeyStroke
 func EngineSetRestoreKeyStroke(engine uintptr) {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return
 	}
@@ -66,7 +66,7 @@ func EngineSetRestoreKeyStroke(engine uintptr) {
 
 //export EnginePullPreedit
 func EnginePullPreedit(engine uintptr) *C.char {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return nil
 	}
@@ -75,7 +75,7 @@ func EnginePullPreedit(engine uintptr) *C.char {
 
 //export EngineCommitPreedit
 func EngineCommitPreedit(engine uintptr) {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return
 	}
@@ -84,7 +84,7 @@ func EngineCommitPreedit(engine uintptr) {
 
 //export EnginePullCommit
 func EnginePullCommit(engine uintptr) *C.char {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return nil
 	}
@@ -96,7 +96,7 @@ func EnginePullCommit(engine uintptr) *C.char {
 
 //export EngineSetMacroEnabled
 func EngineSetMacroEnabled(engine uintptr, enabled bool) {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return
 	}
@@ -105,7 +105,7 @@ func EngineSetMacroEnabled(engine uintptr, enabled bool) {
 
 //export EngineSetOption
 func EngineSetOption(engine uintptr, option *C.FcitxBambooEngineOption) {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return
 	}
@@ -148,12 +148,12 @@ func EngineSetOption(engine uintptr, option *C.FcitxBambooEngineOption) {
 
 //export NewEngine
 func NewEngine(name *C.cchar, dictHandle uintptr, tableHandle uintptr) uintptr {
-	dict, ok := cgo.Handle(dictHandle).Value().(*map[string]bool)
+	dict, ok := dictionaryFromHandle(dictHandle)
 	if !ok {
 		return 0
 	}
 
-	table, ok := cgo.Handle(tableHandle).Value().(*MacroTable)
+	table, ok := macroTableFromHandle(tableHandle)
 	if !ok {
 		return 0
 	}
@@ -182,12 +182,12 @@ func NewEngine(name *C.cchar, dictHandle uintptr, tableHandle uintptr) uintptr {
 
 //export NewCustomEngine
 func NewCustomEngine(definition **C.char, dictHandle uintptr, tableHandle uintptr) uintptr {
-	dict, ok := cgo.Handle(dictHandle).Value().(*map[string]bool)
+	dict, ok := dictionaryFromHandle(dictHandle)
 	if !ok {
 		return 0
 	}
 
-	table, ok := cgo.Handle(tableHandle).Value().(*MacroTable)
+	table, ok := macroTableFromHandle(tableHandle)
 	if !ok {
 		return 0
 	}
@@ -242,12 +242,12 @@ func NewMacroTable(definition **C.char) uintptr {
 
 //export DeleteObject
 func DeleteObject(handle uintptr) {
-	cgo.Handle(handle).Delete()
+	deleteHandle(handle)
 }
 
 //export ResetEngine
 func ResetEngine(engine uintptr) {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return
 	}
@@ -256,7 +256,7 @@ func ResetEngine(engine uintptr) {
 
 //export EngineRebuildFromText
 func EngineRebuildFromText(engine uintptr, text *C.cchar) {
-	bambooEngine, ok := cgo.Handle(engine).Value().(*FcitxBambooEngine)
+	bambooEngine, ok := engineFromHandle(engine)
 	if !ok {
 		return
 	}

--- a/bamboo/handles.go
+++ b/bamboo/handles.go
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026-2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+package main
+
+import "runtime/cgo"
+
+// The C++ side reports "there is nothing here" by passing a zero handle:
+// CGoObject::handle() returns 0 when empty, LotusEngine::macroTable() returns 0
+// when no input method is configured, and NewDictionary/NewEngine return 0 when
+// they fail. cgo.Handle(0).Value() and .Delete() both panic on such a handle,
+// and a panic here takes the whole fcitx5 process down, so every handle coming
+// from C has to be checked before it is used.
+
+func engineFromHandle(h uintptr) (*FcitxBambooEngine, bool) {
+	if h == 0 {
+		return nil, false
+	}
+	engine, ok := cgo.Handle(h).Value().(*FcitxBambooEngine)
+	return engine, ok
+}
+
+func macroTableFromHandle(h uintptr) (*MacroTable, bool) {
+	if h == 0 {
+		return nil, false
+	}
+	table, ok := cgo.Handle(h).Value().(*MacroTable)
+	return table, ok
+}
+
+func dictionaryFromHandle(h uintptr) (*map[string]bool, bool) {
+	if h == 0 {
+		return nil, false
+	}
+	dict, ok := cgo.Handle(h).Value().(*map[string]bool)
+	return dict, ok
+}
+
+func deleteHandle(h uintptr) {
+	if h == 0 {
+		return
+	}
+	cgo.Handle(h).Delete()
+}

--- a/bamboo/handles_test.go
+++ b/bamboo/handles_test.go
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nguyen Hoang Ky <nhktmdzhg@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+package main
+
+import (
+	"runtime/cgo"
+	"testing"
+)
+
+// A zero handle is how the C++ side reports "there is nothing here":
+// CGoObject::handle() returns 0 when empty, LotusEngine::macroTable() returns 0
+// when no input method is configured, and NewDictionary/NewEngine return 0 on
+// failure. cgo.Handle(0).Value() panics, so the helpers must reject 0 before
+// touching the handle.
+func TestHandleHelpersRejectZeroHandle(t *testing.T) {
+	if engine, ok := engineFromHandle(0); ok || engine != nil {
+		t.Errorf("engineFromHandle(0) got [%v,%v] expected [nil,false]", engine, ok)
+	}
+	if table, ok := macroTableFromHandle(0); ok || table != nil {
+		t.Errorf("macroTableFromHandle(0) got [%v,%v] expected [nil,false]", table, ok)
+	}
+	if dict, ok := dictionaryFromHandle(0); ok || dict != nil {
+		t.Errorf("dictionaryFromHandle(0) got [%v,%v] expected [nil,false]", dict, ok)
+	}
+	deleteHandle(0) // must not panic
+}
+
+func TestHandleHelpersRoundTrip(t *testing.T) {
+	engine := &FcitxBambooEngine{}
+	handle := uintptr(cgo.NewHandle(engine))
+	defer deleteHandle(handle)
+
+	got, ok := engineFromHandle(handle)
+	if !ok || got != engine {
+		t.Errorf("engineFromHandle(valid) got [%v,%v] expected [%v,true]", got, ok, engine)
+	}
+	// A handle holding another type must be reported as a miss, not returned.
+	if table, ok := macroTableFromHandle(handle); ok || table != nil {
+		t.Errorf("macroTableFromHandle(engine handle) got [%v,%v] expected [nil,false]", table, ok)
+	}
+}


### PR DESCRIPTION
# Mô tả

Một handle không hợp lệ đi từ C++ sang Go sẽ **làm sập cả tiến trình fcitx5**, kéo theo bộ gõ của người dùng.

Các hàm cgo được xuất ra trông như đã xử lý trường hợp handle hỏng:

```go
dict, ok := cgo.Handle(dictHandle).Value().(*map[string]bool)
if !ok {
    return 0
}
```

Nhưng `cgo.Handle.Value()` **panic** khi handle không hợp lệ, nên luồng chạy không bao giờ tới được phép kiểm tra `ok`. `cgo.Handle.Delete()` trong `DeleteObject` cũng vậy.

Đã đo trực tiếp: `cgo.Handle(0).Value()` và `cgo.Handle(0).Delete()` đều panic với `runtime/cgo: misuse of an invalid Handle`, và dạng viết `, ok` không đỡ được.

**Vì sao gặp được trong vận hành bình thường.** Phía C++ dùng số 0 để nói "ở đây không có gì":

- `CGoObject::handle()` trả `0` khi rỗng — chú thích trong `src/lotus.h` ghi đúng như vậy. Khi **không định vị được file từ điển**, `dictionary_` không bao giờ được `reset()`, nên `LotusEngine::dictionary()` đưa handle 0 cho `NewEngine`.
- `LotusEngine::macroTable()` (`src/lotus-engine.cpp:193`) **cố ý** trả `0` khi cấu hình `inputMethod` rỗng.
- `NewEngine` / `NewCustomEngine` / `NewDictionary` cũng trả `0` khi thất bại. `CGoObject::reset(0)` cất số 0 đó lại như một giá trị hợp lệ, và `~CGoObject` sau đó gọi `DeleteObject(0)`.

Số 0 đi thẳng vào `NewEngine(...)` ở `src/lotus-state.cpp:57`.

**Cách sửa.** Chuyển phần tra handle sang `bamboo/handles.go`, nơi chặn handle 0 **trước khi** chạm vào nó, rồi cho mọi hàm được xuất ra đi qua các helper này (14 chỗ gọi). `handles.go` import `runtime/cgo` nhưng **không** import `"C"`, nên khác với `bamboo-c.go`, nó có thể được test — Go không cho phép file `_test.go` dùng cgo, và đó là lý do lớp này xưa nay có độ phủ 0%.

PR này không đổi hành vi khi handle hợp lệ.

## Loại thay đổi

- [ ] Tính năng mới
- [x] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD

## Liên kết issue

Không có issue tương ứng — phát hiện khi chạy bộ test của #451 trên máy chưa cài file từ điển.

## Screenshot (cho UI changes)

Không đổi giao diện.

# Test

Hai bài test mới trong `bamboo/handles_test.go`:

- `TestHandleHelpersRejectZeroHandle` — cả bốn helper phải từ chối handle 0 mà không panic. Đã xác nhận bài này **thật sự bắt được lỗi**: chạy trên bản chưa sửa thì nó panic ngay.
- `TestHandleHelpersRoundTrip` — handle hợp lệ vẫn tra ra đúng đối tượng, và handle mang kiểu khác vẫn được báo là "không khớp" chứ không trả bừa.

**Kiểm chứng đầu-cuối bằng bộ test C++ của #451**, chạy trong đúng điều kiện gây sập (chưa `make install` nên không có `vietnamese.cm.dict`):

| Điều kiện | Trước PR này | Sau PR này |
|---|---|---|
| Không có file từ điển | 6 bài `Subprocess aborted` (panic) | 5 bài `Failed` bình thường, **0 lần panic trong log** |
| Có đủ dữ liệu (`XDG_DATA_DIRS` trỏ tới prefix đã cài) | 8/8 xanh | 8/8 xanh |

Nói cách khác: cú sập trở thành một lỗi bình thường, và không có hồi quy khi mọi thứ đầy đủ.

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [x] `clang-format` — không áp dụng: PR không đổi file C/C++ nào, chỉ đổi phía Go
- [x] Build C++ thành công (`cmake .. && make`) — dựng sạch trên Ubuntu 24.04, fcitx5 5.1.7
- [x] Test pass (`cd bamboo/ && go test -race ./...`), cùng với `go vet ./...` và `gofmt -l *_test.go` sạch
- [x] Đã rebase với nhánh `dev` mới nhất (5220797)
- [ ] Các CI checks pass:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
