### PR TITLE
WIP: feat: implement UinputShiftSelect rewrite mode with serialized key bu…

### DIFF
--- a/docs/technical-spec-uinput-shift-select.md
+++ b/docs/technical-spec-uinput-shift-select.md
@@ -1,0 +1,307 @@
+# Tài Liệu Kỹ Thuật Chuyên Sâu: Cơ Chế Shift+Left Selection Rewrite (`UinputShiftSelect`)
+
+Tài liệu đặc tả kỹ thuật nội bộ (Technical Specification & Architecture) dành cho lập trình viên bảo trì và phát triển **Fcitx5 Lotus**. Tài liệu này mô tả chi tiết kiến trúc luồng dữ liệu, máy trạng thái, giao thức IPC, cơ chế đồng bộ hóa tuần tự và chiến lược phòng chống race condition.
+
+---
+
+## 1. Tổng Quan Kiến Trúc (Architecture Overview)
+
+Chế độ `UinputShiftSelect` được thiết kế nhằm thay thế cơ chế xóa bằng `KEY_BACKSPACE` truyền thống bằng phương pháp **bôi đen vùng chọn và ghi đè (Selection-and-Overwrite)**.
+
+### 1.1. Các thành phần tham gia
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Fcitx5 Process (User Space)                 │
+│                                                                 │
+│  [KeyEvent In] ──► [LotusState::keyEvent]                       │
+│                           │                                     │
+│       ┌───────────────────┴───────────────────┐                 │
+│       ▼                                       ▼                 │
+│  [is_deleting_ == true]              [is_deleting_ == false]    │
+│       │                                       │                 │
+│  [Push to buffered_keys_]            [EngineProcessKeyEvent]    │
+│  [filterAndAccept()]                          │                 │
+│                                      [compareAndSplitStrings]   │
+│                                               │                 │
+│                                      [performShiftSelect]       │
+│                                               │                 │
+│                                      (send ShiftSelectMsg)      │
+│                                               │                 │
+└───────────────────────────────────────────────┼─────────────────┘
+                                                │ Unix Domain Socket
+                                                │ (/tmp/fcitx5-lotus.sock)
+┌───────────────────────────────────────────────┼─────────────────┐
+│  fcitx5-lotus-server Daemon (Root / Input)    │                 │
+│                                               ▼                 │
+│                       [Server recv ShiftSelectMsg]              │
+│                                   │                             │
+│                      [KEY_LEFTSHIFT Down]                       │
+│                      [Delay 2ms]                                │
+│                      [KEY_LEFT x N (2ms/phím)]                  │
+│                      [Delay 2ms]                                │
+│                      [KEY_LEFTSHIFT Up]                         │
+│                                   │                             │
+│                      [Send ACK 'D' to socket] ──────────────────┼──┐
+└─────────────────────────────────────────────────────────────────┘  │
+                                                                     │
+┌─────────────────────────────────────────────────────────────────┐  │
+│  Fcitx5 EventLoop (IO Callback & Timers)                        │  │
+│                                                                 │  │
+│  [shiftSelectAckListener_] ◄────────────────────────────────────┴──┘
+│            │
+│            ▼
+│  [onShiftSelectDone()] ──► [Commit First Char]
+│                                   │
+│                            [Delay 5ms via EventLoop]
+│                                   │
+│                            [Commit Rest Chars]
+│                                   │
+│                            [Delay 20ms Barrier]
+│                                   │
+│                            [is_deleting_ = false]
+│                                   │
+│                            [replayBufferedKeys()] ──► [Tuần tự hóa từng key]
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Giao Thức Giao Tiếp IPC (Socket Protocol)
+
+- **Kênh truyền**: Unix Domain Stream Socket (`/tmp/fcitx5-lotus.sock`).
+- **Phía Server**: Chạy quyền `root` để ghi vào `/dev/uinput`.
+- **Phía Client**: Chạy trong ngữ cảnh người dùng của process `fcitx5`.
+
+### 2.1. Cấu trúc thông điệp yêu cầu (`ShiftSelectMsg`)
+
+Định nghĩa tại `src/lotus-state.h`:
+
+```cpp
+#pragma pack(push, 1)
+struct ShiftSelectMsg {
+    uint8_t type;    // Luôn bằng 1 (Đại diện cho lệnh Shift-Select)
+    int32_t nLeft;   // Số lượng ký tự cần lùi (số lần nhấn phím KEY_LEFT)
+};
+#pragma pack(pop)
+```
+
+- `type`: Định danh tác vụ. `1` = Bôi đen ngược về bên trái `nLeft` ký tự.
+- `nLeft`: Số codepoint UTF-8 cần chọn lùi, tính bằng `utf8::length(deletedPart)`.
+
+### 2.2. Tín hiệu phản hồi (Acknowledgement)
+
+- Server gửi đúng **1 byte duy nhất**: `'D'` (ASCII `0x44` - Done).
+- Client không sử dụng hàm `read()` chặn (blocking), mà đăng ký IO Watcher trên `EventLoop` của Fcitx5:
+  ```cpp
+  el.addIOEvent(fd, IOEventFlag::In, [this, icRef](EventSourceIO*, int, IOEventFlags) -> bool { ... });
+  ```
+
+---
+
+## 3. Quản Lý Trạng Thái & Bộ Nhớ Chia Sẻ (State & Concurrency)
+
+### 3.1. Các cờ nguyên tử (Atomic Flags)
+
+| Biến nguyên tử | Vị trí định nghĩa | Ý nghĩa kỹ thuật | Memory Order |
+| :--- | :--- | :--- | :--- |
+| `is_deleting_` | `src/lotus-utils.h` | Đánh dấu hệ thống đang trong chu trình xóa/rewrite hoặc trong rào cản hậu commit. Khi `true`, **tuyệt đối không cho phép phím mới lọt vào engine**. | `std::memory_order_acquire` / `release` |
+| `lastCommitTimeUsec_` | `src/lotus-utils.h` | Thời điểm kết thúc lần commit chuỗi gần nhất (tính theo `CLOCK_MONOTONIC` microsecond). Dùng để từ chối các tín hiệu reset giả từ hệ thống. | `std::memory_order_acquire` / `release` |
+| `needEngineReset` | `src/lotus-utils.h` | Báo hiệu chuột click từ server (`lotus-monitor`). Bị trì hoãn xử lý nếu `is_deleting_ == true`. | `std::memory_order_acquire` / `release` |
+
+### 3.2. Cấu trúc hàng đợi đệm phím (`buffered_keys_`)
+
+Định nghĩa tại `src/lotus-state.h`:
+
+```cpp
+struct BufferedKeyInfo {
+    uint32_t sym;    // KeySym của phím (ví dụ: FcitxKey_n)
+    uint32_t state;  // Trạng thái tổ hợp phím (Modifier state: Shift, Caps, etc.)
+};
+
+std::vector<BufferedKeyInfo> buffered_keys_;
+static constexpr size_t MAX_BUFFERED_KEYS = 32;
+```
+
+---
+
+## 4. Cơ Chế Thực Thi Chi Tiết (Implementation Details)
+
+### 4.1. Khởi động Rewrite: `performShiftSelectReplacement`
+
+Được kích hoạt khi bộ gõ phát hiện chuỗi mới khác chuỗi cũ và có phần cần xóa (`deletedPart` không rỗng):
+
+```cpp
+void LotusState::performShiftSelectReplacement(const std::string& deletedPart, const std::string& addedPart);
+```
+
+1. **Kiểm tra `nLeft`**:
+   - Nếu `nLeft <= 0`: Không có ký tự nào cần bôi đen xóa, trực tiếp gọi `ic_->commitString(addedPart)`, bật `is_deleting_ = true` và hẹn giờ barrier 20ms.
+2. **Tách chuỗi thêm mới (`addedPart`)**:
+   - Tách thành ký tự UTF-8 đầu tiên (`shiftSelectFirstChar_`) và phần còn lại (`shiftSelectRestChars_`).
+   - Việc tách này đảm bảo ký tự đầu tiên sẽ ghi đè và xóa sạch vùng đang chọn (highlighted text).
+3. **Bật rào cản**:
+   - `is_deleting_.store(true, std::memory_order_release)`.
+4. **Gửi lệnh IPC**:
+   - Gửi `ShiftSelectMsg{1, nLeft}` tới socket server.
+5. **Đăng ký IO Event phi chặn**:
+   - Sử dụng `EventLoop::addIOEvent` để theo dõi socket FD.
+   - Nhận `'D'` -> hủy IO watcher -> gọi `onShiftSelectDone()`.
+
+### 4.2. Tiếp nhận ACK & Commit: `onShiftSelectDone`
+
+```cpp
+void LotusState::onShiftSelectDone();
+```
+
+Quy trình commit 2 giai đoạn:
+1. **Commit First Char**: Sau thời gian `uinputShiftSelectDelayMs` (mặc định 0ms), commit `shiftSelectFirstChar_`. Ký tự này ngay lập tức xóa vùng chọn trên UI ứng dụng.
+2. **Commit Rest Chars**: Nếu `shiftSelectRestChars_` không rỗng, hẹn giờ sau **5ms** commit tiếp chuỗi còn lại.
+3. **Post-Commit Barrier (20ms)**:
+   - Cả 2 nhánh đều kết thúc bằng:
+     ```cpp
+     scheduleShiftSelect(20, [this]() {
+         is_deleting_.store(false);
+         replayBufferedKeys();
+     });
+     ```
+   - Trong suốt 20ms này, `is_deleting_` vẫn là `true`.
+
+### 4.3. Timer An Toàn Phi Chặn: `scheduleShiftSelect`
+
+```cpp
+void LotusState::scheduleShiftSelect(uint32_t delayMs, std::function<void()> callback);
+```
+
+- Tuyệt đối không dùng `sleep` hay `this_thread::sleep_for` trên main thread của Fcitx5 (tránh treo toàn bộ hệ thống nhập liệu).
+- Sử dụng `EventLoop::addTimeEvent(CLOCK_MONOTONIC, ...)` của Fcitx5.
+- Cơ chế tự giải phóng an toàn trước khi gọi callback:
+  ```cpp
+  auto completed = std::move(shiftSelectTimer_);
+  cb();
+  ```
+  Ngăn chặn việc callback gọi tiếp `scheduleShiftSelect` dẫn đến việc timer tự hủy chính nó trong khi callback đang chạy.
+
+### 4.4. Cơ Chế Tuần Tự Hóa Hàng Đợi: `replayBufferedKeys`
+
+```cpp
+void LotusState::replayBufferedKeys();
+```
+
+Khi người dùng gõ chuỗi phím cực nhanh (ví dụ: `k h o o n g` với phím `o` và `n` sát nhau):
+1. Phím `n` và `g` đến khi `is_deleting_ == true` -> Được gom vào `buffered_keys_`.
+2. Khi barrier 20ms của `ô` hết hạn, `replayBufferedKeys()` được gọi.
+3. **Nguyên tắc "One Key at a Time"**:
+   - Lấy phím đầu tiên: `keyInfo = buffered_keys_.front()`, `buffered_keys_.erase(...)`.
+   - Bơm vào engine qua `EngineProcessKeyEvent`.
+   - Nếu sinh ra chuỗi cần commit (kể cả ký tự mới không có thay thế):
+     - Gọi `ic_->commitString(...)`.
+     - Cập nhật `lastCommitTimeUsec_`.
+     - **Tái kích hoạt cờ bận**: `is_deleting_.store(true, std::memory_order_release)`.
+     - **Hẹn giờ 20ms tiếp theo**:
+       ```cpp
+       scheduleShiftSelect(20, [this]() {
+           is_deleting_.store(false);
+           replayBufferedKeys();
+       });
+       ```
+     - Kết thúc hàm (`return`).
+4. **Kết quả**: Mỗi ký tự trong buffer được phân tách cách nhau chính xác ít nhất 20ms, đảm bảo thứ tự commit trên ứng dụng luôn đạt 100% độ chính xác (`khô` -> đợi 20ms -> `khôn` -> đợi 20ms -> `không`).
+
+---
+
+## 5. Chiến Lược Chống Reset (Anti-Reset Strategy)
+
+Một trong những nguyên nhân lớn nhất làm hỏng quá trình gõ tiếng Việt là các sự kiện Reset đột ngột từ hệ điều hành hoặc ứng dụng khi nhận được các phím tổng hợp từ uinput (`Shift`, `Left`).
+
+### 5.1. Hàm `shouldRejectReset()` (`src/lotus-utils.cpp`)
+
+```cpp
+bool shouldRejectReset() {
+    // 1. Đang trong quá trình xóa / rewrite
+    if (is_deleting_.load(std::memory_order_acquire)) {
+        return true;
+    }
+    // 2. Nằm trong cửa sổ an toàn 50ms sau commit
+    uint64_t last = lastCommitTimeUsec_.load(std::memory_order_acquire);
+    if (last > 0) {
+        uint64_t now = fcitx::now(CLOCK_MONOTONIC);
+        if (now >= last && (now - last) < 50000ULL) {
+            return true;
+        }
+    }
+    return false;
+}
+```
+
+### 5.2. Các điểm chốt chặn (Interception Points)
+
+1. **`LotusEngine::reset()`**:
+   ```cpp
+   if (shouldRejectReset()) return;
+   ```
+2. **`LotusState::reset()`**:
+   ```cpp
+   if (shouldRejectReset()) return;
+   ```
+3. **`LotusState::clearAllBuffers()`**:
+   ```cpp
+   if (shouldRejectReset()) return;
+   ```
+4. **`LotusState::checkForwardSpecialKey()`**:
+   Khi các phím `Shift` hoặc `Left` từ uinput dội ngược về frontend của Fcitx5:
+   ```cpp
+   if (keyEvent.key().isCursorMove() || keyEvent.key().hasModifier()) {
+       if (shouldRejectReset()) {
+           return true; // Forward phím mà KHÔNG reset buffer engine
+       }
+   }
+   ```
+5. **Bỏ qua kiểm tra Backspace ở đầu `keyEvent()`**:
+   ```cpp
+   if (realMode != LotusMode::UinputShiftSelect && expected_backspaces_ > 0 && 
+       current_backspace_count_ >= expected_backspaces_ && is_deleting_.load()) {
+       // Chỉ chạy với các mode dùng Backspace
+   }
+   ```
+
+---
+
+## 6. Tham Số Điều Khiển (Configuration Parameters)
+
+Được cấu hình thông qua file cấu hình Fcitx5 hoặc giao diện cài đặt (`src/lotus-config.h`):
+
+| Tên cấu hình | Kiểu dữ liệu | Mặc định | Ý nghĩa |
+| :--- | :--- | :--- | :--- |
+| `rewriteMode` | `LotusMode` | `UinputShiftSelect` | Chế độ viết lại văn bản (Enums: Off, SurroundingText, Uinput, Smooth, SuperSmooth, Minecraft, Preedit, Emoji, UinputShiftSelect). |
+| `uinputShiftSelectDelayMs` | `int` | `20` ms | Thời gian chờ giữa lúc nhận ACK từ uinput server và lúc commit ký tự đầu tiên đè lên vùng chọn. |
+| *Barrier Delay* (Hardcoded) | `uint32_t` | `20` ms | Thời gian rào cản cách ly giữa các lần commit ký tự liên tiếp để ứng dụng kịp đồng bộ buffer đồ họa. |
+| *Post-commit Anti-reset* (Hardcoded) | `uint64_t` | `50` ms | Cửa sổ thời gian từ chối mọi yêu cầu reset engine từ hệ thống sau khi commit chuỗi. |
+
+---
+
+## 7. Hướng Dẫn Debug & Kiểm Tra Lỗi
+
+### 7.1. Bật log debug Fcitx5
+
+Chạy Fcitx5 trong terminal để xem log chi tiết thời gian thực:
+
+```bash
+G_MESSAGES_DEBUG=all fcitx5 -r --verbose *=5
+```
+
+### 7.2. Các log điểm mốc quan trọng (Log Trace)
+
+Một chu kỳ viết lại thành công của `k h o o n g` sẽ có trace log như sau:
+
+```text
+[INFO] Perform shift-select replacement: o -> ô
+[INFO] Sent shift-select msg: nLeft=1
+[WARN] Typing so fast, add key to queue: n   <-- Phím 'n' được bảo vệ trong buffer
+[INFO] ShiftSelect done ACK received
+[INFO] ShiftSelect commit first: ô
+[INFO] Starting replay buffered keys
+[INFO] Replay commit added: n                 <-- Phím 'n' được commit sau barrier 20ms
+[INFO] Starting replay buffered keys
+[INFO] Replay commit added: g                 <-- Phím 'g' được commit sau barrier 20ms
+```

--- a/docs/uinput-shift-select.md
+++ b/docs/uinput-shift-select.md
@@ -1,0 +1,190 @@
+# Chế Độ Gõ Shift + Left Selection Rewrite (`UinputShiftSelect`)
+
+Tài liệu kỹ thuật giải thích nguyên lý hoạt động, kiến trúc client-server, cơ chế đồng bộ hóa tuần tự (serialization) và bảo vệ chống reset (anti-reset) của chế độ viết lại văn bản bằng vùng chọn `Shift + Left` trong **Fcitx5 Lotus**.
+
+---
+
+## 1. Giới thiệu & Mục đích
+
+Trong các bộ gõ tiếng Việt trên Linux, khi người dùng gõ thêm dấu hoặc thay đổi nguyên âm (ví dụ: gõ `o` tiếp theo chữ `o` để tạo thành `ô`), bộ gõ cần thay thế (rewrite) chuỗi ký tự đã hiển thị trên màn hình.
+
+Trước đây, có hai cách tiếp cận chính:
+1. **Dùng Surrounding Text**: Phụ thuộc vào ứng dụng có hỗ trợ Wayland/X11 Surrounding Text hay không (nhiều ứng dụng Electron, Chromium, Terminal hoặc Game không hỗ trợ hoặc hỗ trợ lỗi).
+2. **Dùng Backspace (Uinput / Smooth / SuperSmooth)**: Gửi liên tiếp các phím `KEY_BACKSPACE` để xóa ký tự cũ rồi gõ lại ký tự mới. Cách này khi gõ nhanh dễ gây giật màn hình (flicker), nuốt phím, hoặc xung đột race condition nếu ứng dụng xử lý phím bất đồng bộ.
+
+**Chế độ `UinputShiftSelect` (Shift + Left Selection Rewrite)** ra đời nhằm giải quyết triệt để các vấn đề trên:
+- **Không dùng Backspace**: Thay vì bấm xóa nhiều lần, bộ gõ giả lập tổ hợp `Shift + Left` để **bôi đen (select)** đoạn ký tự cần thay thế, sau đó commit ký tự mới **đè trực tiếp** lên đoạn vừa chọn.
+- **Mượt mà và ổn định**: Loại bỏ hiện tượng nhấp nháy chữ, giảm số lượng phím giả lập, tương thích tốt với hầu hết ứng dụng trên Wayland và X11.
+
+---
+
+## 2. Kiến Trúc & Quy Trình Hoạt Động (Flow)
+
+Chế độ hoạt động theo mô hình Client-Server giao tiếp qua Unix Domain Socket:
+- **Client**: Module Fcitx5 Lotus (`src/lotus-state.cpp`, `src/lotus-engine.cpp`).
+- **Server**: Tiến trình daemon `fcitx5-lotus-server` chạy quyền root, truy cập trực tiếp vào `/dev/uinput`.
+
+### Sơ đồ tuần tự (Sequence Diagram)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as Người dùng
+    participant State as Fcitx5 Lotus (Client)
+    participant Server as fcitx5-lotus-server
+    participant App as Ứng dụng đích (Editor/Browser)
+
+    User->>State: Gõ phím biến đổi (ví dụ: 'o' thứ 2 trong 'kho')
+    State->>State: So sánh chuỗi (deletedPart='o', addedPart='ô')
+    State->>State: Bật cờ bận is_deleting_ = true
+    State->>Server: Gửi ShiftSelectMsg {type: 1, nLeft: 1}
+    
+    rect rgb(240, 248, 255)
+    Note over Server: Server thực hiện chuỗi uinput
+    Server->>App: Gửi KEY_LEFTSHIFT (Down)
+    Server->>Server: Delay 2ms
+    loop lặp nLeft lần (1 lần)
+        Server->>App: Gửi KEY_LEFT (Down -> Up)
+        Server->>Server: Delay 2ms
+    end
+    Server->>Server: Delay 2ms
+    Server->>App: Gửi KEY_LEFTSHIFT (Up)
+    Server->>State: Gửi byte ACK 'D' qua socket
+    end
+
+    opt Người dùng gõ phím tiếp theo (ví dụ: 'n')
+        User->>State: Phím 'n' đến
+        State->>State: is_deleting_ đang true -> Giữ 'n' vào buffered_keys_
+    end
+
+    State->>State: Nhận ACK 'D' (onShiftSelectDone)
+    State->>App: Commit ký tự đầu: 'ô' (thay thế vùng chọn)
+    State->>State: Chờ 20ms (Post-commit barrier)
+    
+    State->>State: Hết 20ms: is_deleting_ = false
+    State->>State: Kích hoạt replayBufferedKeys()
+    State->>App: Commit tiếp phím 'n' từ buffer
+```
+
+---
+
+## 3. Chi Tiết Các Cơ Chế Cốt Lõi
+
+### 3.1. Phía Server (`server/lotus-server.cpp`)
+
+Khi nhận gói tin `ShiftSelectMsg`:
+1. Nhấn giữ phím `KEY_LEFTSHIFT`.
+2. Đợi **2ms** để OS và ứng dụng ghi nhận trạng thái Shift.
+3. Lặp `nLeft` lần:
+   - Gửi sự kiện `KEY_LEFT` (nhấn và nhả).
+   - Đợi **2ms** sau mỗi phím Left.
+4. Đợi **2ms** để hoàn tất vùng chọn.
+5. Nhả phím `KEY_LEFTSHIFT`.
+6. Gửi byte phản hồi `'D'` (Done ACK) qua socket về cho Fcitx5 client.
+
+```cpp
+// server/lotus-server.cpp
+uinput_send_key(fd, KEY_LEFTSHIFT, 1);
+std::this_thread::sleep_for(std::chrono::milliseconds(2));
+for (int i = 0; i < msg.nLeft; ++i) {
+    uinput_send_key(fd, KEY_LEFT, 1);
+    uinput_send_key(fd, KEY_LEFT, 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+}
+std::this_thread::sleep_for(std::chrono::milliseconds(2));
+uinput_send_key(fd, KEY_LEFTSHIFT, 0);
+::send(client_fd, "D", 1, MSG_NOSIGNAL);
+```
+
+### 3.2. Phía Client & Cơ Chế Commit Hai Giai Đoạn
+
+Sau khi nhận được tín hiệu hoàn tất `'D'` từ server:
+1. **Commit ký tự đầu tiên (`shiftSelectFirstChar_`)**: Ghi đè trực tiếp lên vùng đang được bôi đen.
+2. **Commit các ký tự còn lại (`shiftSelectRestChars_`)**: Nếu chuỗi thay thế có nhiều hơn 1 ký tự (ví dụ thay `ung` -> `úng` thì commit `ú`, sau đó 5ms commit `ng`), các ký tự còn lại được commit qua timer phi chặn `EventLoop::addTimeEvent`.
+
+### 3.3. Cơ Chế Chống Nuốt Phím & Đồng Bộ Tuần Tự (Sequencing)
+
+Một vấn đề phổ biến khi gõ tốc độ cao (ví dụ gõ `k h o o n g` với phím `o` và `n` bấm gần như đồng thời):
+- Phím `n` có thể bị gửi tới ứng dụng trước khi quá trình bôi đen và commit `ô` hoàn thành, dẫn tới từ bị đảo thành `khnôg`.
+
+Để ngăn chặn hoàn toàn hiện tượng này:
+1. **Cờ Bận `is_deleting_`**:
+   - Khi bắt đầu rewrite hoặc commit, `is_deleting_` được đặt thành `true`.
+   - Bất kỳ phím nào người dùng gõ trong khoảng thời gian này sẽ **bị chặn ngay lập tức** và đưa vào hàng đợi `buffered_keys_` bằng `filterAndAccept()`.
+2. **Khóa logic Backspace hoàn tất**:
+   - Kiểm tra `realMode != LotusMode::UinputShiftSelect && expected_backspaces_ > 0` để tránh việc `0 >= 0` làm tắt `is_deleting_` ngoài ý muốn.
+3. **Post-commit Barrier (20ms)**:
+   - Sau khi ký tự được commit, hệ thống **duy trì cờ `is_deleting_ = true` thêm 20ms**.
+   - Hết 20ms này, timer mới gỡ cờ và kích hoạt `replayBufferedKeys()`.
+4. **Xử lý tuần tự từng phím trong hàng đợi đệm (`replayBufferedKeys`)**:
+   - Mỗi lần chạy, hệ thống chỉ lấy **duy nhất 1 phím** ở đầu hàng đợi ra xử lý.
+   - Nếu phím đó dẫn tới commit (kể cả ký tự mới không có thay thế), hệ thống lại tiếp tục đặt cờ bận và hoãn 20ms trước khi cho phép phím tiếp theo được pump ra màn hình.
+
+```cpp
+// src/lotus-state.cpp - replayBufferedKeys()
+if (realMode == LotusMode::UinputShiftSelect) {
+    auto keyInfo = buffered_keys_.front();
+    buffered_keys_.erase(buffered_keys_.begin());
+    // ... Xử lý phím ...
+    ic_->commitString(addedPart);
+    is_deleting_.store(true, std::memory_order_release);
+    scheduleShiftSelect(20, [this]() {
+        is_deleting_.store(false);
+        replayBufferedKeys();
+    });
+    return;
+}
+```
+
+### 3.4. Cơ Chế Chống Reset Đột Ngột (Anti-Reset)
+
+Khi Fcitx5 hoặc server uinput bơm các phím `Shift` hoặc phím di chuyển con trỏ `Left`, hệ thống hoặc ứng dụng có thể phát ra các sự kiện như reset trạng thái gõ, focus change, hoặc mouse click ảo.
+Hàm `shouldRejectReset()` được triển khai để bảo vệ:
+- Kiểm tra xem `is_deleting_` có đang bật hay không.
+- Kiểm tra xem thời điểm hiện tại có nằm trong khoảng an toàn **50ms** kể từ lần commit cuối cùng (`lastCommitTimeUsec_`) hay không.
+- Nếu thỏa mãn, mọi yêu cầu reset engine từ bên ngoài đều bị từ chối, bảo đảm tính toàn vẹn của lịch sử từ đang gõ.
+
+```cpp
+// src/lotus-utils.cpp
+bool shouldRejectReset() {
+    if (is_deleting_.load(std::memory_order_acquire)) {
+        return true;
+    }
+    uint64_t last = lastCommitTimeUsec_.load(std::memory_order_acquire);
+    if (last > 0) {
+        uint64_t now = fcitx::now(CLOCK_MONOTONIC);
+        if (now >= last && (now - last) < 50000ULL) { // 50ms
+            return true;
+        }
+    }
+    return false;
+}
+```
+
+---
+
+## 4. Bảng So Sánh Các Chế Độ Rewrite Trong Lotus
+
+| Tiêu chí | Backspace Thường (`Uinput`/`Smooth`) | Surrounding Text | **Shift + Left Selection (`UinputShiftSelect`)** |
+| :--- | :--- | :--- | :--- |
+| **Cơ chế xóa** | Gửi N phím Backspace | Gọi API deleteSurroundingText | Gửi `Shift + Left` x N lần |
+| **Hiện tượng nhấp nháy** | Có thể thấy chữ bị lùi và gõ lại | Không | Cực kỳ mượt (vùng chọn bị thay tức thì) |
+| **Độ tương thích app** | Trung bình - Khá | Kém (nhiều app không hỗ trợ) | **Rất cao** (hầu hết app đều hỗ trợ Shift+Left) |
+| **Độ ổn định khi gõ nhanh** | Dễ bị nuốt phím nếu máy lag | Dễ crash/mất focus trên app lỗi | **Rất cao** (có barrier 20ms và buffer tuần tự) |
+| **Yêu cầu quyền** | Cần uinput server (root) | Không cần root | Cần uinput server (root) |
+
+---
+
+## 5. Hướng Dẫn Cấu Hình
+
+1. Mở phần Cài đặt của **Fcitx5** -> Chọn cấu hình **Lotus**.
+2. Tại mục **Chế độ viết lại (Rewrite Mode)**, chọn:
+   ```text
+   Uinput (Shift+Left Selection)
+   ```
+3. Cấu hình độ trễ:
+   - `uinputShiftSelectDelayMs`: Thời gian chờ giữa lúc server bôi đen xong (nhận ACK 'D') và lúc client commit ký tự đầu tiên đè lên vùng chọn (mặc định: **20 ms**).
+
+> **Lưu ý về 2 khoảng chờ 20ms trong quy trình**:
+> 1. **Chờ sau khi bôi đen (Delay After Select - 20ms)**: Sau khi server gửi xong `Shift + Left`, hệ thống chờ 20ms để ứng dụng đích hiển thị hoàn tất vùng bôi đen rồi mới commit ký tự đầu tiên.
+> 2. **Chờ sau khi commit (Post-commit Barrier - 20ms)**: Sau khi commit xong ký tự mới, hệ thống duy trì cờ bận thêm 20ms để ứng dụng đích ghi nhận văn bản hoàn tất rồi mới pump phím tiếp theo từ hàng đợi.

--- a/server/lotus-server.cpp
+++ b/server/lotus-server.cpp
@@ -52,7 +52,10 @@ bool UinputDevice::initialize() {
         return false;
     guard_.reset(fd);
 
-    if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0 || ioctl(fd, UI_SET_KEYBIT, KEY_BACKSPACE) < 0) {
+    if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0 ||
+        ioctl(fd, UI_SET_KEYBIT, KEY_BACKSPACE) < 0 ||
+        ioctl(fd, UI_SET_KEYBIT, KEY_LEFT) < 0 ||
+        ioctl(fd, UI_SET_KEYBIT, KEY_LEFTSHIFT) < 0) {
         return false;
     }
 
@@ -69,6 +72,17 @@ bool UinputDevice::initialize() {
     return true;
 }
 
+void UinputDevice::emit_key(int code, int value) {
+    if (!guard_.is_valid())
+        return;
+    struct input_event ev[2]{};
+    ev[0].type  = EV_KEY;
+    ev[0].code  = static_cast<unsigned short>(code);
+    ev[0].value = value;
+    // ev[1] is zero-initialized → SYN_REPORT
+    write(guard_.get(), ev, sizeof(ev));
+}
+
 void UinputDevice::send_backspace() {
     if (!guard_.is_valid())
         return;
@@ -82,6 +96,27 @@ void UinputDevice::send_backspace() {
     ev[2].value = 0; // Release
     // Zero-initialize ev[3] via {} set this event to SYN_REPORT
     write(guard_.get(), ev, sizeof(ev));
+}
+
+void UinputDevice::send_shift_select(int count, int client_fd) {
+    if (!guard_.is_valid() || count <= 0)
+        return;
+    // Shift DOWN
+    emit_key(KEY_LEFTSHIFT, 1);
+    usleep(2000); // 2ms settle after Shift down
+    // Press Left N times while Shift is held (each with 2ms delay)
+    for (int i = 0; i < count; ++i) {
+        emit_key(KEY_LEFT, 1);
+        emit_key(KEY_LEFT, 0);
+        usleep(2000); // 2ms between each Left key
+    }
+    usleep(2000); // 2ms before releasing Shift
+    // Shift UP
+    emit_key(KEY_LEFTSHIFT, 0);
+    // Send done ACK "D" to the fcitx5 addon
+    if (client_fd >= 0) {
+        send(client_fd, "D", 1, MSG_NOSIGNAL | MSG_DONTWAIT);
+    }
 }
 
 LibinputContext::LibinputContext(const struct libinput_interface* interface) : udev_(udev_new()) {
@@ -327,15 +362,24 @@ int main(int argc, char* argv[]) {
 
         // handle connect from addon
         if (fds[KB_CLIENT_INDEX].fd >= 0 && (fds[KB_CLIENT_INDEX].revents & (POLLIN | POLLHUP | POLLERR)) != 0) {
-            int     count = 0;
-            ssize_t n     = recv(fds[KB_CLIENT_INDEX].fd, &count, sizeof(count), 0);
+            ShiftSelectMsg msg{};
+            ssize_t        n = recv(fds[KB_CLIENT_INDEX].fd, &msg, sizeof(msg), 0);
             if (n <= 0) {
                 LotusLogger::instance().warn("Keyboard client disconnected or connection error");
                 kb_client_fd.reset(-1);
                 fds[KB_CLIENT_INDEX].fd = -1;
-            } else {
+            } else if (n == sizeof(int)) {
+                // Legacy: client sent only an int (backspace count)
+                int count = msg.type; // msg.type holds the int value
                 pending_backspaces += count - 1;
                 uinput.send_backspace();
+            } else if (msg.type == 0) {
+                // type=0: backspace mode
+                pending_backspaces += msg.count - 1;
+                uinput.send_backspace();
+            } else if (msg.type == 1) {
+                // type=1: shift+left select
+                uinput.send_shift_select(msg.count, kb_client_fd.get());
             }
         }
 

--- a/server/lotus-server.h
+++ b/server/lotus-server.h
@@ -60,6 +60,16 @@ class FdGuard {
 };
 
 /**
+ * @brief Protocol message for keyboard socket.
+ * type=0: send N backspaces (legacy)
+ * type=1: Shift+Left select N chars, then send done ACK
+ */
+struct ShiftSelectMsg {
+    int type;  ///< 0 = backspace, 1 = shift+select
+    int count; ///< number of keys to send
+};
+
+/**
  * @brief RAII Wrapper for uinput device.
  * Handles UI_DEV_CREATE and UI_DEV_DESTROY automatically.
  */
@@ -76,12 +86,19 @@ class UinputDevice {
 
     bool          initialize();
     void          send_backspace();
+    /**
+     * @brief Sends Shift+Left N times to select N chars, then sends done ACK.
+     * @param count Number of Left key presses.
+     * @param client_fd Socket fd to send ACK "D" after completion.
+     */
+    void          send_shift_select(int count, int client_fd);
     int           get_fd() const {
         return guard_.get();
     }
 
   private:
     FdGuard guard_;
+    void    emit_key(int code, int value);
 };
 
 /**

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -35,10 +35,11 @@ namespace fcitx {
         Preedit,
         Emoji,
         Minecraft,
+        UinputShiftSelect, ///< Replaces text via Shift+Left selection
     };
 
     FCITX_CONFIG_ENUM_NAME_WITH_I18N(LotusMode, N_("OFF"), N_("Uinput (Smooth)"), N_("Uinput (Super Smooth)"), N_("Uinput (Slow)"), N_("Surrounding Text"), N_("Preedit"),
-                                     N_("Emoji Picker"), N_("Minecraft"));
+                                     N_("Emoji Picker"), N_("Minecraft"), N_("Uinput (Shift Select)"));
 
     /**
      * @brief Converts LotusMode to int and vice versa.
@@ -262,11 +263,14 @@ namespace fcitx {
         Option<std::string> shortcutEmoji{this, "ShortcutEmoji", _("Shortcut for Emoji Picker"), "w"}; Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true};
         Option<std::string> shortcutOff{this, "ShortcutOff", _("Shortcut for OFF"), "e"}; Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
         Option<std::string> shortcutDefault{this, "ShortcutDefault", _("Shortcut for Default Typing"), "r"};
+        Option<bool>        showModeUinputShiftSelect{this, "ShowModeUinputShiftSelect", _("Show Uinput (Shift Select)"), true};
+        Option<std::string> shortcutUinputShiftSelect{this, "ShortcutUinputShiftSelect", _("Shortcut for Uinput (Shift Select)"), "b"};
+        Option<int>         uinputShiftSelectDelayMs{this, "UinputShiftSelectDelayMs", _("Uinput Shift Select: Delay After Select (ms)"), 20};
         Option<bool>        enableMacroInOffMode{this, "EnableMacroInOffMode", _("Allow Macro in Off Mode"), false};
 
         Option<bool>        useSurroundingTextIfPossible{this, "useSurroundingTextIfPossible", _("Use Surrounding Text if possible"), false};
 
-        Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default"};
+        Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,UinputShiftSelect,Default"};
 
         OptionWithAnnotation<std::string, TimeFormatAnnotation>  timeFormat{this, "TimeFormat", _("Time Format ($TIME in macro)"), "%H:%M", {}, {}, TimeFormatAnnotation()};
         OptionWithAnnotation<std::string, DateFormatAnnotation>  dateFormat{this, "DateFormat", _("Date Format ($DATE in macro)"), "%d/%m/%Y", {}, {}, DateFormatAnnotation()};

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -51,6 +51,7 @@ namespace fcitx {
             case LotusMode::Preedit: return 5;
             case LotusMode::Emoji: return 6;
             case LotusMode::Minecraft: return 8;
+            case LotusMode::UinputShiftSelect: return 9;
             default: return 0;
         }
     }
@@ -65,6 +66,7 @@ namespace fcitx {
             case 5: return LotusMode::Preedit;
             case 6: return LotusMode::Emoji;
             case 8: return LotusMode::Minecraft;
+            case 9: return LotusMode::UinputShiftSelect;
             default: return LotusMode::Off;
         }
     }
@@ -75,7 +77,8 @@ namespace fcitx {
     static bool isAppModeMenuReservedKey(KeySym sym, const lotusConfig& config) {
         if (sym == Key(*config.shortcutSmooth).sym() || sym == Key(*config.shortcutUinput).sym() || sym == Key(*config.shortcutMinecraft).sym() ||
             sym == Key(*config.shortcutSurroundingText).sym() || sym == Key(*config.shortcutPreedit).sym() || sym == Key(*config.shortcutEmoji).sym() ||
-            sym == Key(*config.shortcutOff).sym() || sym == Key(*config.shortcutSuperSmooth).sym() || sym == Key(*config.shortcutDefault).sym()) {
+            sym == Key(*config.shortcutOff).sym() || sym == Key(*config.shortcutSuperSmooth).sym() || sym == Key(*config.shortcutDefault).sym() ||
+            sym == Key(*config.shortcutUinputShiftSelect).sym()) {
             return true;
         }
 
@@ -456,7 +459,9 @@ namespace fcitx {
 
         state->waitAck_ = false;
         if (*config_.fixUinputWithAck) {
-            if (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth) {
+            if (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth ||
+                targetMode == LotusMode::UinputShiftSelect) {
+
 #if __cplusplus >= 202002L
                 std::ranges::transform(appName, appName.begin(), ::tolower);
 #else
@@ -657,7 +662,8 @@ namespace fcitx {
                                                                     {"Emoji", *config_.showModeEmoji},
                                                                     {"Off", *config_.showModeOff},
                                                                     {"SuperSmooth", *config_.showModeSuperSmooth},
-                                                                    {"Default", *config_.showModeDefault}};
+                                                                    {"Default", *config_.showModeDefault},
+                                                                    {"UinputShiftSelect", *config_.showModeUinputShiftSelect}};
 
             std::vector<LotusMode>                    enabledModes;
             for (const auto& name : order) {
@@ -688,6 +694,8 @@ namespace fcitx {
                         mode = LotusMode::SuperSmooth;
                     else if (name == "Default")
                         mode = config().mode.value();
+                    else if (name == "UinputShiftSelect")
+                        mode = LotusMode::UinputShiftSelect;
                     else
                         continue;
 
@@ -746,6 +754,10 @@ namespace fcitx {
     }
 
     void LotusEngine::reset(const InputMethodEntry& /*entry*/, InputContextEvent& event) {
+        if (shouldRejectReset()) {
+            LOTUS_INFO("areca-style: app reset rejected (active deletion or 20ms post-commit window)");
+            return;
+        }
         LOTUS_INFO("Reset engine");
         auto* state = event.inputContext()->propertyFor(&factory_);
         if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut) {
@@ -770,11 +782,12 @@ namespace fcitx {
                 state->lastDeactivateTime_ = now_ms();
                 LOTUS_INFO("Skip clearAllBuffers");
             } else {
-                if (surrvalid && !state->oldPreBuffer_.empty())
+                if (surrvalid && !state->oldPreBuffer_.empty() && !is_deleting_.load(std::memory_order_acquire))
                     state->clearAllBuffers();
             }
-            is_deleting_.store(false);
-            needEngineReset.store(false);
+            if (!is_deleting_.load(std::memory_order_acquire)) {
+                needEngineReset.store(false);
+            }
             ic->inputPanel().reset();
             ic->updateUserInterface(UserInterfaceComponent::InputPanel);
             if (realMode == LotusMode::Preedit || realMode == LotusMode::Emoji || realMode == LotusMode::SurroundingText)
@@ -989,6 +1002,7 @@ namespace fcitx {
             {"Emoji", {LotusMode::Emoji, _("Emoji Picker"), getShortcut(*config_.shortcutEmoji), *config_.showModeEmoji}},
             {"Off", {LotusMode::Off, _("OFF"), getShortcut(*config_.shortcutOff), *config_.showModeOff}},
             {"SuperSmooth", {LotusMode::SuperSmooth, _("Uinput (Super Smooth)"), getShortcut(*config_.shortcutSuperSmooth), *config_.showModeSuperSmooth}},
+            {"UinputShiftSelect", {LotusMode::UinputShiftSelect, _("Uinput (Shift Select)"), getShortcut(*config_.shortcutUinputShiftSelect), *config_.showModeUinputShiftSelect}},
             {"Default", {config_.mode.value(), _("Default Typing"), getShortcut(*config_.shortcutDefault), *config_.showModeDefault}}};
 
         std::vector<ModeInfo> allModes;
@@ -1098,6 +1112,7 @@ namespace fcitx {
             case LotusMode::Emoji: modeLabel = _("Emoji Picker"); break;
             case LotusMode::Off: modeLabel = _("OFF"); break;
             case LotusMode::SuperSmooth: modeLabel = _("Uinput (Super Smooth)"); break;
+            case LotusMode::UinputShiftSelect: modeLabel = _("Uinput (Shift Select)"); break;
             default: modeLabel = _("Unknown Mode"); break;
         }
 
@@ -1129,6 +1144,9 @@ namespace fcitx {
     }
 
     void LotusEngine::setMode(LotusMode mode, InputContext* ic) {
+        if (realMode == mode && ic != nullptr) {
+            return;
+        }
         realMode = mode;
         if (ic != nullptr) {
             if (auto* state = ic->propertyFor(&factory_)) {

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -463,6 +463,7 @@ namespace fcitx {
             }
             ic_->commitString(pending_commit_string_);
             LOTUS_INFO("Commit: " + pending_commit_string_);
+            lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
             expected_backspaces_     = 0;
             current_backspace_count_ = 0;
             pending_commit_string_.clear();
@@ -476,6 +477,11 @@ namespace fcitx {
     }
 
     void LotusState::performReplacement(const std::string& deletedPart, const std::string& addedPart) {
+        // Delegate to shift-select method when in UinputShiftSelect mode
+        if (realMode.load() == LotusMode::UinputShiftSelect) {
+            performShiftSelectReplacement(deletedPart, addedPart);
+            return;
+        }
         LOTUS_INFO("Perform replacement: " + deletedPart + " -> " + addedPart); //NOLINT
         current_backspace_count_      = 0;
         pending_commit_string_        = addedPart;
@@ -504,6 +510,7 @@ namespace fcitx {
             if (!pending_commit_string_.empty()) {
                 ic_->commitString(pending_commit_string_);
                 LOTUS_INFO("Commit: " + pending_commit_string_);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                 std::this_thread::sleep_for(std::chrono::milliseconds(3 * utf8::length(addedPart)));
             }
             expected_backspaces_     = 0;
@@ -517,9 +524,158 @@ namespace fcitx {
         LOTUS_INFO("Send " + std::to_string(expected_backspaces_) + " backspaces");
     }
 
+    void LotusState::performShiftSelectReplacement(const std::string& deletedPart, const std::string& addedPart) {
+        LOTUS_INFO("Perform shift-select replacement: " + deletedPart + " -> " + addedPart); //NOLINT
+
+        if (uinput_client_fd_ < 0 && !connect_uinput_server()) {
+            LOTUS_ERROR("Cannot connect to uinput server for shift-select, falling back to backspace");
+            performReplacement(deletedPart, addedPart);
+            return;
+        }
+
+        const int nLeft = static_cast<int>(utf8::length(deletedPart));
+        if (nLeft <= 0) {
+            // Nothing to delete, just commit
+            if (!addedPart.empty()) {
+                ic_->commitString(addedPart);
+                LOTUS_INFO("Commit (no delete): " + addedPart);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                is_deleting_.store(true, std::memory_order_release);
+                scheduleShiftSelect(20, [this]() {
+                    is_deleting_.store(false);
+                    replayBufferedKeys();
+                });
+            }
+            return;
+        }
+
+        // Split addedPart into first UTF-8 char + rest
+        // Per user spec: commit first char, delay 5ms, then commit rest
+        shiftSelectFirstChar_.clear();
+        shiftSelectRestChars_.clear();
+        if (!addedPart.empty()) {
+            auto   range    = fcitx::utf8::MakeUTF8CharRange(addedPart);
+            auto   it       = range.begin();
+            size_t firstLen = 0;
+            if (it != range.end()) {
+                // Get byte length of the first codepoint
+                const char* ptr = addedPart.data();
+                firstLen        = fcitx_utf8_char_len(ptr);
+                if (firstLen == 0 || firstLen > addedPart.size())
+                    firstLen = 1;
+                shiftSelectFirstChar_ = addedPart.substr(0, firstLen);
+                shiftSelectRestChars_ = addedPart.size() > firstLen ? addedPart.substr(firstLen) : "";
+            }
+        }
+
+        is_deleting_.store(true, std::memory_order_release);
+
+        // Send ShiftSelectMsg type=1 to server
+        ShiftSelectMsg msg{1, nLeft};
+        ssize_t        sent = ::send(uinput_client_fd_.load(std::memory_order_acquire), &msg, sizeof(msg), MSG_NOSIGNAL);
+        if (sent < 0) {
+            LOTUS_WARN("Failed to send shift-select msg, falling back");
+            is_deleting_.store(false);
+            performReplacement(deletedPart, addedPart);
+            return;
+        }
+
+        LOTUS_INFO("Sent shift-select msg: nLeft=" + std::to_string(nLeft));
+
+        // Cancel any previous listener
+        shiftSelectAckListener_.reset();
+        shiftSelectTimer_.reset();
+
+        // Watch the socket for done ACK "D" from server — no sleep, EventLoop IO callback
+        int            fd = uinput_client_fd_.load(std::memory_order_acquire);
+        auto&          el = engine_->instance()->eventLoop();
+        auto           icRef = ic_->watch();
+        shiftSelectAckListener_ = el.addIOEvent(fd, IOEventFlag::In, [this, icRef](EventSourceIO*, int, IOEventFlags) -> bool {
+            // Read the ACK byte
+            char    buf[4] = {};
+            ssize_t n      = ::recv(uinput_client_fd_.load(std::memory_order_acquire), buf, sizeof(buf), MSG_DONTWAIT);
+            if (n <= 0 || buf[0] != 'D') {
+                // Not our ACK or error — keep waiting (or handle error)
+                if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+                    return true; // keep watching
+                LOTUS_WARN("Unexpected data on uinput socket, aborting shift-select");
+                shiftSelectAckListener_.reset();
+                is_deleting_.store(false);
+                return false;
+            }
+            // Got done ACK — stop IO watcher then schedule commit
+            shiftSelectAckListener_.reset();
+            if (icRef.get() != nullptr) {
+                onShiftSelectDone();
+            }
+            return false; // one-shot
+        });
+    }
+
+    void LotusState::scheduleShiftSelect(uint32_t delayMs, std::function<void()> callback) {
+        shiftSelectTimer_.reset();
+        auto& el  = engine_->instance()->eventLoop();
+        auto  now = ::fcitx::now(CLOCK_MONOTONIC);
+        shiftSelectTimer_ = el.addTimeEvent(CLOCK_MONOTONIC, now + static_cast<uint64_t>(delayMs) * 1000ULL, 0,
+            [this, cb = std::move(callback)](EventSourceTime*, uint64_t) -> bool {
+                auto completed = std::move(shiftSelectTimer_);
+                cb();
+                return false;
+            });
+    }
+
+    void LotusState::onShiftSelectDone() {
+        LOTUS_INFO("ShiftSelect done ACK received");
+        const int delayMs = *engine_->config().uinputShiftSelectDelayMs;
+
+        auto icRef = ic_->watch();
+        scheduleShiftSelect(delayMs, [this, icRef]() {
+            // First char commit
+            if (!shiftSelectFirstChar_.empty()) {
+                if (auto* ic = icRef.get()) {
+                    ic->commitString(shiftSelectFirstChar_);
+                    LOTUS_INFO("ShiftSelect commit first: " + shiftSelectFirstChar_);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                }
+            }
+            std::string rest = std::move(shiftSelectRestChars_);
+            shiftSelectFirstChar_.clear();
+            shiftSelectRestChars_.clear();
+
+            if (rest.empty()) {
+                // Done committing: wait 20ms post-commit barrier before processing next key
+                scheduleShiftSelect(20, [this]() {
+                    is_deleting_.store(false);
+                    replayBufferedKeys();
+                });
+                return;
+            }
+
+            // Schedule rest commit after 5ms
+            scheduleShiftSelect(5, [this, rest = std::move(rest), icRef]() {
+                if (auto* ic = icRef.get()) {
+                    ic->commitString(rest);
+                    LOTUS_INFO("ShiftSelect commit rest: " + rest);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                }
+                // Done committing: wait 20ms post-commit barrier before processing next key
+                scheduleShiftSelect(20, [this]() {
+                    is_deleting_.store(false);
+                    replayBufferedKeys();
+                });
+            });
+        });
+    }
+
+
     bool LotusState::checkForwardSpecialKey(KeyEvent& keyEvent, KeySym& currentSym) {
         if (keyEvent.key().isCursorMove() || currentSym == FcitxKey_Tab || currentSym == FcitxKey_KP_Tab || currentSym == FcitxKey_ISO_Left_Tab || currentSym == FcitxKey_Escape ||
             keyEvent.key().hasModifier()) {
+            if (shouldRejectReset()) {
+                // Cursor/modifier keys injected by uinput during or within post-commit window of a rewrite.
+                // Forward without resetting state.
+                return true;
+            }
             is_deleting_.store(false, std::memory_order_release);
             expected_backspaces_     = 0;
             current_backspace_count_ = 0;
@@ -634,7 +790,15 @@ namespace fcitx {
                     }
                     ic_->commitString(addedPart);
                     LOTUS_INFO("Commit: " + addedPart);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                     keyEvent.filterAndAccept();
+                    if (realMode == LotusMode::UinputShiftSelect) {
+                        is_deleting_.store(true, std::memory_order_release);
+                        scheduleShiftSelect(20, [this]() {
+                            is_deleting_.store(false);
+                            replayBufferedKeys();
+                        });
+                    }
                 } else {
                     keyEvent.forward();
                 }
@@ -679,9 +843,17 @@ namespace fcitx {
                     if (wa_chromium_flag || wasAutoCapitalized || addedPart != keyUtf8) {
                         ic_->commitString(addedPart);
                         LOTUS_INFO("Commit: " + addedPart);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                         if (!wa_chromium_flag) {
                             keyEvent.filterAndAccept();
                             isCommit = true;
+                        }
+                        if (realMode == LotusMode::UinputShiftSelect) {
+                            is_deleting_.store(true, std::memory_order_release);
+                            scheduleShiftSelect(20, [this]() {
+                                is_deleting_.store(false);
+                                replayBufferedKeys();
+                            });
                         }
                     }
                 }
@@ -1005,7 +1177,7 @@ namespace fcitx {
             LOTUS_WARN("Cannot connect to uinput server, reconnecting....");
             connect_uinput_server();
         }
-        if (current_backspace_count_ >= expected_backspaces_ && is_deleting_.load()) {
+        if (realMode != LotusMode::UinputShiftSelect && expected_backspaces_ > 0 && current_backspace_count_ >= expected_backspaces_ && is_deleting_.load()) {
             is_deleting_.store(false);
             current_backspace_count_ = 0;
             expected_backspaces_     = 0;
@@ -1078,6 +1250,10 @@ namespace fcitx {
                 if (handleUInputKeyPress(keyEvent, currentSym, (realMode == LotusMode::Smooth || realMode == LotusMode::SuperSmooth) ? 2 : 8)) {
                     return;
                 }
+            } else if (keyEvent.key().isCursorMove() || keyEvent.rawKey().isModifier()) {
+                // Injected by uinput (Shift, Left) during rewrite: forward directly
+                keyEvent.forward();
+                return;
             } else {
                 std::string keyUtf8Check = Key::keySymToUTF8(currentSym);
                 if (!keyUtf8Check.empty() && buffered_keys_.size() < MAX_BUFFERED_KEYS) {
@@ -1123,7 +1299,8 @@ namespace fcitx {
             case LotusMode::Uinput:
             case LotusMode::Smooth:
             case LotusMode::Minecraft:
-            case LotusMode::SuperSmooth: {
+            case LotusMode::SuperSmooth:
+            case LotusMode::UinputShiftSelect: {
                 handleUinputMode(keyEvent, currentSym);
                 break;
             }
@@ -1154,7 +1331,7 @@ namespace fcitx {
         const auto& text        = surrounding.text();
         size_t      textLen     = utf8::length(text);
         realtextLen.store(textLen, std::memory_order_release);
-        if (is_deleting_.load(std::memory_order_acquire)) {
+        if (shouldRejectReset()) {
             return;
         }
         resetMacroSkip();
@@ -1190,7 +1367,8 @@ namespace fcitx {
             case LotusMode::Uinput:
             case LotusMode::Smooth:
             case LotusMode::Minecraft:
-            case LotusMode::SuperSmooth: {
+            case LotusMode::SuperSmooth:
+            case LotusMode::UinputShiftSelect: {
                 ic_->inputPanel().reset();
                 break;
             }
@@ -1225,10 +1403,14 @@ namespace fcitx {
             case LotusMode::Smooth:
             case LotusMode::SurroundingText:
             case LotusMode::Minecraft:
-            case LotusMode::SuperSmooth: {
+            case LotusMode::SuperSmooth:
+            case LotusMode::UinputShiftSelect: {
                 if (lotusEngine_) {
                     ResetEngine(lotusEngine_.handle());
                 }
+                // Cancel any in-progress shift-select sequence
+                shiftSelectAckListener_.reset();
+                shiftSelectTimer_.reset();
                 break;
             }
             default: {
@@ -1239,7 +1421,7 @@ namespace fcitx {
 
     void LotusState::clearAllBuffers() {
         LOTUS_DEBUG("Clear all buffers");
-        if (is_deleting_.load(std::memory_order_acquire)) {
+        if (shouldRejectReset()) {
             return;
         }
         resetMacroSkip();
@@ -1270,6 +1452,106 @@ namespace fcitx {
         if (buffered_keys_.empty()) {
             return;
         }
+        if (is_deleting_.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        if (realMode == LotusMode::UinputShiftSelect) {
+            auto keyInfo = buffered_keys_.front();
+            buffered_keys_.erase(buffered_keys_.begin());
+
+            auto        sym     = static_cast<KeySym>(keyInfo.sym);
+            uint32_t    state   = keyInfo.state;
+            std::string keyUtf8 = Key::keySymToUTF8(sym);
+            if (keyUtf8.empty()) {
+                replayBufferedKeys();
+                return;
+            }
+
+            bool processed = EngineProcessKeyEvent(lotusEngine_.handle(), sym, state) != 0U;
+
+            auto commitF = UniqueCPtr<char>(EnginePullCommit(lotusEngine_.handle()));
+            if (commitF && (*commitF.get() != 0)) {
+                std::string commitStr = commitF.get();
+                std::string deletedPart;
+                std::string addedPart;
+                compareAndSplitStrings(oldPreBuffer_, commitStr, deletedPart, addedPart);
+
+                hasHistory_ = false;
+                ResetEngine(lotusEngine_.handle());
+                oldPreBuffer_.clear();
+
+                if (!deletedPart.empty()) {
+                    performReplacement(deletedPart, addedPart);
+                    return;
+                }
+                if (!addedPart.empty()) {
+                    ic_->commitString(addedPart);
+                    LOTUS_INFO("Replay commit: " + addedPart);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                    is_deleting_.store(true, std::memory_order_release);
+                    scheduleShiftSelect(20, [this]() {
+                        is_deleting_.store(false);
+                        replayBufferedKeys();
+                    });
+                    return;
+                }
+                replayBufferedKeys();
+                return;
+            }
+
+            if (!processed) {
+                ic_->commitString(keyUtf8);
+                LOTUS_INFO("Replay commit raw: " + keyUtf8);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                is_deleting_.store(true, std::memory_order_release);
+                scheduleShiftSelect(20, [this]() {
+                    is_deleting_.store(false);
+                    replayBufferedKeys();
+                });
+                return;
+            }
+
+            hasHistory_ = true;
+            realtextLen.fetch_add(1, std::memory_order_acq_rel);
+
+            UniqueCPtr<char> preeditC(EnginePullPreedit(lotusEngine_.handle()));
+            std::string      preeditStr = (preeditC && (*preeditC.get() != 0)) ? preeditC.get() : "";
+
+            std::string      deletedPart;
+            std::string      addedPart;
+            if (compareAndSplitStrings(oldPreBuffer_, preeditStr, deletedPart, addedPart) != 0) {
+                if (deletedPart.empty()) {
+                    if (!addedPart.empty()) {
+                        ic_->commitString(addedPart);
+                        LOTUS_INFO("Replay commit added: " + addedPart);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                        oldPreBuffer_ = preeditStr;
+                        is_deleting_.store(true, std::memory_order_release);
+                        scheduleShiftSelect(20, [this]() {
+                            is_deleting_.store(false);
+                            replayBufferedKeys();
+                        });
+                        return;
+                    }
+                    replayBufferedKeys();
+                    return;
+                } else {
+                    if (uinput_client_fd_ < 0) {
+                        ic_->commitString(keyUtf8);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                        replayBufferedKeys();
+                        return;
+                    }
+                    performReplacement(deletedPart, addedPart);
+                    oldPreBuffer_ = preeditStr;
+                    return;
+                }
+            }
+            replayBufferedKeys();
+            return;
+        }
+
         auto keys = std::move(buffered_keys_);
         buffered_keys_.clear();
         for (size_t i = 0; i < keys.size(); ++i) {
@@ -1304,6 +1586,7 @@ namespace fcitx {
                 }
                 if (!addedPart.empty()) {
                     ic_->commitString(addedPart);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                 }
 
                 hasHistory_ = false;
@@ -1314,6 +1597,7 @@ namespace fcitx {
 
             if (!processed) {
                 ic_->commitString(keyUtf8);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                 continue;
             }
 
@@ -1329,11 +1613,13 @@ namespace fcitx {
                 if (deletedPart.empty()) {
                     if (!addedPart.empty()) {
                         ic_->commitString(addedPart);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                         oldPreBuffer_ = preeditStr;
                     }
                 } else {
                     if (uinput_client_fd_ < 0) {
                         ic_->commitString(keyUtf8);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                         continue;
                     }
 

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -20,7 +20,9 @@
 #include "lotus-utils.h"
 
 #include <cstddef>
+#include <functional>
 #include <fcitx-utils/misc.h>
+#include <fcitx-utils/event.h>
 #include <fcitx/inputcontext.h>
 
 struct EmojiEntry;
@@ -108,6 +110,14 @@ namespace fcitx {
         bool                    tracking_modifier_tap_ = false; ///< Selected modifier held, waiting for consecutive keyup
         bool                    macro_skip_            = false; ///< Macro disabled for the current word
 
+        // UinputShiftSelect mode state
+        std::unique_ptr<EventSourceTime> shiftSelectTimer_;       ///< EventLoop timer for shift-select sequencing
+        std::unique_ptr<EventSourceIO>   shiftSelectAckListener_; ///< IO watcher waiting for server done ACK
+        std::string                      shiftSelectFirstChar_;    ///< First UTF-8 char to commit
+        std::string                      shiftSelectRestChars_;    ///< Remaining chars to commit after delay
+        void scheduleShiftSelect(uint32_t delayMs, std::function<void()> callback);
+
+
         /**
          * @brief Connects to the uinput server.
          * @return True if connection successful.
@@ -167,11 +177,26 @@ namespace fcitx {
         bool handleUInputKeyPress(KeyEvent& event, KeySym currentSym, int sleepTime);
 
         /**
-         * @brief Performs text replacement via uinput.
+         * @brief Performs text replacement via uinput (backspace method).
          * @param deletedPart Text to delete.
          * @param addedPart Text to insert.
          */
         void performReplacement(const std::string& deletedPart, const std::string& addedPart);
+
+        /**
+         * @brief Performs text replacement via Shift+Left selection (UinputShiftSelect mode).
+         * Sends a ShiftSelectMsg to server, waits for done ACK via EventSourceIO,
+         * then commits addedPart with a small delay via EventLoop.
+         * @param deletedPart Text to select and replace.
+         * @param addedPart Text to insert after selection.
+         */
+        void performShiftSelectReplacement(const std::string& deletedPart, const std::string& addedPart);
+
+        /**
+         * @brief Called when server sends done ACK for shift-select.
+         * Schedules commit of first char then rest.
+         */
+        void onShiftSelectDone();
 
         /**
          * @brief Handles the double space to period replacement.

--- a/src/lotus-utils.cpp
+++ b/src/lotus-utils.cpp
@@ -25,8 +25,23 @@ std::atomic<bool>             stop_flag_monitor{false};
 std::atomic<int>              uinput_client_fd_{-1};
 std::atomic<unsigned int>     realtextLen{0};
 std::atomic<int>              mouse_socket_fd{-1};
+std::atomic<uint64_t>         lastCommitTimeUsec_{0};
 
-FCITX_DEFINE_LOG_CATEGORY(lotus, "lotus", fcitx::LogLevel::NoLog);
+FCITX_DEFINE_LOG_CATEGORY(lotus, "lotus", fcitx::LogLevel::Debug);
+
+bool shouldRejectReset() {
+    if (is_deleting_.load(std::memory_order_acquire)) {
+        return true;
+    }
+    uint64_t lastCommit = lastCommitTimeUsec_.load(std::memory_order_acquire);
+    if (lastCommit != 0) {
+        uint64_t now = fcitx::now(CLOCK_MONOTONIC);
+        if (now >= lastCommit && (now - lastCommit) <= 50000) { // 50ms post-commit window
+            return true;
+        }
+    }
+    return false;
+}
 
 std::string buildSocketPath(const char* base_path_suffix) {
     struct passwd  pwd{};

--- a/src/lotus-utils.h
+++ b/src/lotus-utils.h
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <sys/un.h>
 #include <fcitx-utils/log.h>
+#include <fcitx-utils/misc.h>
+#include <fcitx-utils/eventloopinterface.h>
 #include <fcitx/inputcontext.h>
 
 #include "lotus-config.h"
@@ -45,6 +47,13 @@ extern std::atomic<bool>             stop_flag_monitor; ///< Signal to stop moni
 extern std::atomic<int>              uinput_client_fd_; ///< Uinput client file descriptor
 extern std::atomic<unsigned int>     realtextLen;       ///< Current text length
 extern std::atomic<int>              mouse_socket_fd;   ///< Mouse socket file descriptor
+extern std::atomic<uint64_t>         lastCommitTimeUsec_; ///< Timestamp of last rewrite completion in microseconds
+
+/**
+ * @brief Checks whether reset/activate/deactivate should be rejected.
+ * Rejects if deletion is active or within 50ms post-commit window.
+ */
+bool shouldRejectReset();
 
 /**
  * @brief Builds socket path from base suffix.
@@ -107,6 +116,16 @@ std::string getFrontendName(fcitx::InputContext* ic);
 struct KeyEntry {
     uint32_t sym;   ///< Key symbol
     uint32_t state; ///< Key state (modifiers)
+};
+
+/**
+ * @brief Protocol message for keyboard socket (uinput server).
+ * type=0: send N backspaces (legacy int-only compatible)
+ * type=1: Shift+Left select N chars, then server sends done ACK "D"
+ */
+struct ShiftSelectMsg {
+    int type;  ///< 0 = backspace, 1 = shift+select
+    int count; ///< number of keys to send
 };
 
 #endif // _FCITX5_LOTUS_UTILS_H_


### PR DESCRIPTION
…ffer and anti-reset

- Add UinputShiftSelect rewrite backend using Shift+Left uinput simulation instead of Backspace to avoid flicker and race conditions.
- Introduce client-server IPC protocol with ShiftSelectMsg and done ACK.
- Implement post-commit and post-select 20ms barriers via EventLoop timers to ensure deterministic key serialization.
- Serialize key replay in replayBufferedKeys() one key at a time.
- Implement shouldRejectReset() to prevent spurious engine resets during uinput synthetic key injection and post-commit window.
- Add technical specification and user documentation in docs/.

# Mô tả

<!-- Mô tả rõ ràng và chi tiết thay đổi của bạn: vấn đề gì, giải quyết thế nào. -->

## Loại thay đổi

- [x ] Tính năng mới
- [ x] Sửa lỗi
- [x ] Cải thiện hiệu năng
- [ x] Cập nhật tài liệu
- [ ] Cải tiến CI/CD

## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [ x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ x] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [x ] Build C++ thành công (`cmake .. && make`)
- [x ] Test pass (`cd bamboo/ && go test -race ./...`)
- [ x] Đã rebase với nhánh `dev` mới nhất
- [ ] Các CI checks pass:
