### PR TITLE
feat: add Uinput (Backspace) mode with anti-reset and async serializa…

### DIFF
--- a/settings-gui/ui/pages/dynamic_settings.py
+++ b/settings-gui/ui/pages/dynamic_settings.py
@@ -65,6 +65,7 @@ SETTINGS_MAP = {
             "ShortcutSmooth",
             "ShortcutUinput",
             "ShortcutSuperSmooth",
+            "ShortcutUinputBackspace",
             "ShortcutMinecraft",
             "ShortcutSurroundingText",
             "ShortcutPreedit",
@@ -95,6 +96,7 @@ MODE_SHORTCUT_TO_VISIBILITY = {
     "ShortcutSmooth": "ShowModeSmooth",
     "ShortcutUinput": "ShowModeUinput",
     "ShortcutSuperSmooth": "ShowModeSuperSmooth",
+    "ShortcutUinputBackspace": "ShowModeUinputBackspace",
     "ShortcutMinecraft": "ShowModeMinecraft",
     "ShortcutSurroundingText": "ShowModeSurroundingText",
     "ShortcutPreedit": "ShowModePreedit",
@@ -107,6 +109,7 @@ MODE_KEY_TO_INTERNAL_NAME = {
     "ShortcutSmooth": "Smooth",
     "ShortcutUinput": "Uinput",
     "ShortcutSuperSmooth": "SuperSmooth",
+    "ShortcutUinputBackspace": "UinputBackspace",
     "ShortcutMinecraft": "Minecraft",
     "ShortcutSurroundingText": "SurroundingText",
     "ShortcutPreedit": "Preedit",
@@ -454,7 +457,7 @@ class DynamicSettingsPage(QWidget):
         # Get current order from config
         order_str = self.current_values.get(
             "ModeOrder",
-            "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default",
+            "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,UinputBackspace,Default",
         )
         order = order_str.split(",")
 

--- a/src/lotus-config.h
+++ b/src/lotus-config.h
@@ -35,10 +35,11 @@ namespace fcitx {
         Preedit,
         Emoji,
         Minecraft,
+        UinputBackspace,
     };
 
     FCITX_CONFIG_ENUM_NAME_WITH_I18N(LotusMode, N_("OFF"), N_("Uinput (Smooth)"), N_("Uinput (Super Smooth)"), N_("Uinput (Slow)"), N_("Surrounding Text"), N_("Preedit"),
-                                     N_("Emoji Picker"), N_("Minecraft"));
+                                     N_("Emoji Picker"), N_("Minecraft"), N_("Uinput (Backspace)"));
 
     /**
      * @brief Converts LotusMode to int and vice versa.
@@ -262,11 +263,14 @@ namespace fcitx {
         Option<std::string> shortcutEmoji{this, "ShortcutEmoji", _("Shortcut for Emoji Picker"), "w"}; Option<bool> showModeOff{this, "ShowModeOff", _("Show OFF"), true};
         Option<std::string> shortcutOff{this, "ShortcutOff", _("Shortcut for OFF"), "e"}; Option<bool> showModeDefault{this, "ShowModeDefault", _("Show Default Typing"), true};
         Option<std::string> shortcutDefault{this, "ShortcutDefault", _("Shortcut for Default Typing"), "r"};
+        Option<bool>        showModeUinputBackspace{this, "ShowModeUinputBackspace", _("Show Uinput (Backspace)"), true};
+        Option<std::string> shortcutUinputBackspace{this, "ShortcutUinputBackspace", _("Shortcut for Uinput (Backspace)"), "b"};
+        Option<int>         uinputBackspaceAfterWaitMs{this, "UinputBackspaceAfterWaitMs", _("After Backspace Wait Time (ms)"), 10};
         Option<bool>        enableMacroInOffMode{this, "EnableMacroInOffMode", _("Allow Macro in Off Mode"), false};
 
         Option<bool>        useSurroundingTextIfPossible{this, "useSurroundingTextIfPossible", _("Use Surrounding Text if possible"), false};
 
-        Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,Default"};
+        Option<std::string> modeOrder{this, "ModeOrder", _("Mode Order"), "Smooth,Uinput,Minecraft,SurroundingText,Preedit,Emoji,Off,SuperSmooth,UinputBackspace,Default"};
 
         OptionWithAnnotation<std::string, TimeFormatAnnotation>  timeFormat{this, "TimeFormat", _("Time Format ($TIME in macro)"), "%H:%M", {}, {}, TimeFormatAnnotation()};
         OptionWithAnnotation<std::string, DateFormatAnnotation>  dateFormat{this, "DateFormat", _("Date Format ($DATE in macro)"), "%d/%m/%Y", {}, {}, DateFormatAnnotation()};

--- a/src/lotus-engine.cpp
+++ b/src/lotus-engine.cpp
@@ -51,6 +51,7 @@ namespace fcitx {
             case LotusMode::Preedit: return 5;
             case LotusMode::Emoji: return 6;
             case LotusMode::Minecraft: return 8;
+            case LotusMode::UinputBackspace: return 9;
             default: return 0;
         }
     }
@@ -65,6 +66,7 @@ namespace fcitx {
             case 5: return LotusMode::Preedit;
             case 6: return LotusMode::Emoji;
             case 8: return LotusMode::Minecraft;
+            case 9: return LotusMode::UinputBackspace;
             default: return LotusMode::Off;
         }
     }
@@ -75,7 +77,8 @@ namespace fcitx {
     static bool isAppModeMenuReservedKey(KeySym sym, const lotusConfig& config) {
         if (sym == Key(*config.shortcutSmooth).sym() || sym == Key(*config.shortcutUinput).sym() || sym == Key(*config.shortcutMinecraft).sym() ||
             sym == Key(*config.shortcutSurroundingText).sym() || sym == Key(*config.shortcutPreedit).sym() || sym == Key(*config.shortcutEmoji).sym() ||
-            sym == Key(*config.shortcutOff).sym() || sym == Key(*config.shortcutSuperSmooth).sym() || sym == Key(*config.shortcutDefault).sym()) {
+            sym == Key(*config.shortcutOff).sym() || sym == Key(*config.shortcutSuperSmooth).sym() || sym == Key(*config.shortcutDefault).sym() ||
+            sym == Key(*config.shortcutUinputBackspace).sym()) {
             return true;
         }
 
@@ -456,7 +459,7 @@ namespace fcitx {
 
         state->waitAck_ = false;
         if (*config_.fixUinputWithAck) {
-            if (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth) {
+            if (targetMode == LotusMode::Uinput || targetMode == LotusMode::Smooth || targetMode == LotusMode::Minecraft || targetMode == LotusMode::SuperSmooth || targetMode == LotusMode::UinputBackspace) {
 #if __cplusplus >= 202002L
                 std::ranges::transform(appName, appName.begin(), ::tolower);
 #else
@@ -657,6 +660,7 @@ namespace fcitx {
                                                                     {"Emoji", *config_.showModeEmoji},
                                                                     {"Off", *config_.showModeOff},
                                                                     {"SuperSmooth", *config_.showModeSuperSmooth},
+                                                                    {"UinputBackspace", *config_.showModeUinputBackspace},
                                                                     {"Default", *config_.showModeDefault}};
 
             std::vector<LotusMode>                    enabledModes;
@@ -686,6 +690,8 @@ namespace fcitx {
                         mode = LotusMode::Off;
                     else if (name == "SuperSmooth")
                         mode = LotusMode::SuperSmooth;
+                    else if (name == "UinputBackspace")
+                        mode = LotusMode::UinputBackspace;
                     else if (name == "Default")
                         mode = config().mode.value();
                     else
@@ -746,6 +752,13 @@ namespace fcitx {
     }
 
     void LotusEngine::reset(const InputMethodEntry& /*entry*/, InputContextEvent& event) {
+        // Chặn reset ngoài ý muốn: Khi vừa gửi Backspace qua uinput hoặc trong cửa sổ 50ms sau commit,
+        // các app/compositor thường phát sự kiện reset về Fcitx5. Nếu reset lúc này sẽ xóa trắng Bamboo Engine
+        // và làm mất ngữ cảnh đang ghép từ tiếng Việt.
+        if (shouldRejectReset()) {
+            LOTUS_INFO("app reset rejected (active deletion or post-commit window)");
+            return;
+        }
         LOTUS_INFO("Reset engine");
         auto* state = event.inputContext()->propertyFor(&factory_);
         if (!state->isEmptyHistory() && event.type() != EventType::InputContextFocusOut) {
@@ -770,11 +783,14 @@ namespace fcitx {
                 state->lastDeactivateTime_ = now_ms();
                 LOTUS_INFO("Skip clearAllBuffers");
             } else {
-                if (surrvalid && !state->oldPreBuffer_.empty())
+                // Không xóa buffer nếu đang bận gửi uinput backspace để tránh xóa mất từ đang thay thế
+                if (surrvalid && !state->oldPreBuffer_.empty() && !is_deleting_.load(std::memory_order_acquire))
                     state->clearAllBuffers();
             }
-            is_deleting_.store(false);
-            needEngineReset.store(false);
+            // Không xóa cờ needEngineReset nếu đang trong quá trình xóa uinput
+            if (!is_deleting_.load(std::memory_order_acquire)) {
+                needEngineReset.store(false);
+            }
             ic->inputPanel().reset();
             ic->updateUserInterface(UserInterfaceComponent::InputPanel);
             if (realMode == LotusMode::Preedit || realMode == LotusMode::Emoji || realMode == LotusMode::SurroundingText)
@@ -989,6 +1005,7 @@ namespace fcitx {
             {"Emoji", {LotusMode::Emoji, _("Emoji Picker"), getShortcut(*config_.shortcutEmoji), *config_.showModeEmoji}},
             {"Off", {LotusMode::Off, _("OFF"), getShortcut(*config_.shortcutOff), *config_.showModeOff}},
             {"SuperSmooth", {LotusMode::SuperSmooth, _("Uinput (Super Smooth)"), getShortcut(*config_.shortcutSuperSmooth), *config_.showModeSuperSmooth}},
+            {"UinputBackspace", {LotusMode::UinputBackspace, _("Uinput (Backspace)"), getShortcut(*config_.shortcutUinputBackspace), *config_.showModeUinputBackspace}},
             {"Default", {config_.mode.value(), _("Default Typing"), getShortcut(*config_.shortcutDefault), *config_.showModeDefault}}};
 
         std::vector<ModeInfo> allModes;
@@ -1098,6 +1115,7 @@ namespace fcitx {
             case LotusMode::Emoji: modeLabel = _("Emoji Picker"); break;
             case LotusMode::Off: modeLabel = _("OFF"); break;
             case LotusMode::SuperSmooth: modeLabel = _("Uinput (Super Smooth)"); break;
+            case LotusMode::UinputBackspace: modeLabel = _("Uinput (Backspace)"); break;
             default: modeLabel = _("Unknown Mode"); break;
         }
 

--- a/src/lotus-state.cpp
+++ b/src/lotus-state.cpp
@@ -463,6 +463,7 @@ namespace fcitx {
             }
             ic_->commitString(pending_commit_string_);
             LOTUS_INFO("Commit: " + pending_commit_string_);
+            lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
             expected_backspaces_     = 0;
             current_backspace_count_ = 0;
             pending_commit_string_.clear();
@@ -504,6 +505,7 @@ namespace fcitx {
             if (!pending_commit_string_.empty()) {
                 ic_->commitString(pending_commit_string_);
                 LOTUS_INFO("Commit: " + pending_commit_string_);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                 std::this_thread::sleep_for(std::chrono::milliseconds(3 * utf8::length(addedPart)));
             }
             expected_backspaces_     = 0;
@@ -520,6 +522,12 @@ namespace fcitx {
     bool LotusState::checkForwardSpecialKey(KeyEvent& keyEvent, KeySym& currentSym) {
         if (keyEvent.key().isCursorMove() || currentSym == FcitxKey_Tab || currentSym == FcitxKey_KP_Tab || currentSym == FcitxKey_ISO_Left_Tab || currentSym == FcitxKey_Escape ||
             keyEvent.key().hasModifier()) {
+            // Chặn reset ngoài ý muốn: Nếu đang trong tiến trình xóa uinput hoặc trong cửa sổ 50ms sau commit,
+            // các phím điều hướng hoặc phím tắt có modifier không được phép reset engine hay xóa buffer preedit,
+            // chỉ đơn thuần forward phím ra ngoài ứng dụng.
+            if (shouldRejectReset()) {
+                return true;
+            }
             is_deleting_.store(false, std::memory_order_release);
             expected_backspaces_     = 0;
             current_backspace_count_ = 0;
@@ -705,6 +713,206 @@ namespace fcitx {
                 if (!wa_chromium_flag)
                     keyEvent.filterAndAccept();
                 performReplacement(deletedPart, addedPart);
+                oldPreBuffer_ = preeditStr;
+            }
+        }
+    }
+
+    // Lập lịch timer bất đồng bộ trên EventLoop của Fcitx5 để xử lý tuần tự mà không block giao diện
+    void LotusState::scheduleUinputBackspace(uint32_t delayMs, std::function<void()> callback) {
+        uinput_commit_timer_.reset();
+        auto& el  = engine_->instance()->eventLoop();
+        auto  now = ::fcitx::now(CLOCK_MONOTONIC);
+        uinput_commit_timer_ =
+            el.addTimeEvent(CLOCK_MONOTONIC, now + static_cast<uint64_t>(delayMs) * 1000ULL, 0, [this, cb = std::move(callback)](EventSourceTime*, uint64_t) -> bool {
+                auto completed = std::move(uinput_commit_timer_);
+                cb();
+                return false;
+            });
+    }
+
+    // Thực hiện xóa ký tự cũ qua uinput và commit ký tự mới kèm hàng rào an toàn 20ms
+    void LotusState::performUinputBackspaceReplacement(const std::string& deletedPart, const std::string& addedPart) {
+        LOTUS_INFO("UinputBackspace replacement: " + deletedPart + " -> " + addedPart);
+        int backspaceCount = static_cast<int>(utf8::length(deletedPart));
+        if (backspaceCount <= 0) {
+            // Không có ký tự nào cần xóa: commit chuỗi mới và áp dụng barrier 20ms để tuần tự hóa phím tiếp theo
+            if (!addedPart.empty()) {
+                ic_->commitString(addedPart);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                LOTUS_INFO("UinputBackspace commit: " + addedPart);
+                is_deleting_.store(true, std::memory_order_release);
+                scheduleUinputBackspace(5, [this]() {
+                    is_deleting_.store(false);
+                    replayBufferedKeys();
+                });
+            } else {
+                replayBufferedKeys();
+            }
+            return;
+        }
+
+        // Bật cờ xóa để đưa các phím người dùng gõ siêu nhanh vào hàng đợi đệm (buffered_keys_)
+        is_deleting_.store(true, std::memory_order_release);
+        send_backspace_uinput(backspaceCount);
+        LOTUS_INFO("UinputBackspace sent " + std::to_string(backspaceCount) + " backspaces");
+
+        int afterWait = *engine_->config().uinputBackspaceAfterWaitMs;
+        if (afterWait <= 0) {
+            afterWait = 5;
+        } else if (afterWait > 10) {
+            afterWait = 10;
+        }
+        // Tính tổng thời gian uinput server gửi phím (mỗi phím 5ms) cộng thêm thời gian chờ ứng dụng cập nhật
+        int waitTime = (backspaceCount - 1) * 5 + afterWait;
+
+        scheduleUinputBackspace(waitTime, [this, addedPart]() {
+            if (!addedPart.empty()) {
+                ic_->commitString(addedPart);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                LOTUS_INFO("UinputBackspace commit: " + addedPart);
+            }
+            // Hàng rào bảo vệ (Post-commit barrier 5ms): Giữ cờ bận is_deleting_ thêm 5ms sau khi commit
+            // để bảo đảm ứng dụng đã hoàn tất nhận chữ trước khi bơm phím tiếp theo ra màn hình
+            scheduleUinputBackspace(5, [this]() {
+                is_deleting_.store(false);
+                replayBufferedKeys();
+            });
+        });
+    }
+
+    // Xử lý sự kiện bàn phím cho mode UinputBackspace
+    void LotusState::handleUinputBackspaceMode(KeyEvent& keyEvent, KeySym currentSym) {
+        if (checkForwardSpecialKey(keyEvent, currentSym)) {
+            keyEvent.forward();
+            return;
+        }
+
+        if (uinput_client_fd_ < 0) {
+            setup_uinput();
+        }
+
+        // Xử lý phím Backspace hoặc Enter người dùng tự bấm
+        if (isBackspace(currentSym) || currentSym == FcitxKey_Return) {
+            if (isBackspace(currentSym)) {
+                // Nếu đang trong tiến trình xóa uinput tự động hoặc trong 50ms sau commit, forward phím và bỏ qua
+                // không cho lọt vào Bamboo Engine để tránh xóa nhầm trạng thái ghép từ
+                if (shouldRejectReset()) {
+                    keyEvent.forward();
+                    return;
+                }
+                hasHistory_ = true;
+                EngineProcessKeyEvent(lotusEngine_.handle(), FcitxKey_BackSpace, 0);
+                UniqueCPtr<char> preeditC(EnginePullPreedit(lotusEngine_.handle()));
+                oldPreBuffer_ = (preeditC && (*preeditC.get() != 0)) ? preeditC.get() : "";
+            } else {
+                if (shouldRejectReset()) {
+                    keyEvent.forward();
+                    return;
+                }
+                hasHistory_ = false;
+                ResetEngine(lotusEngine_.handle());
+                oldPreBuffer_.clear();
+            }
+            keyEvent.forward();
+            return;
+        }
+
+        std::string keyUtf8 = Key::keySymToUTF8(currentSym);
+        if (keyUtf8.empty()) {
+            keyEvent.forward();
+            return;
+        }
+
+        // Chặn phím không cho lọt thô ra app, nạp vào Bamboo Engine để xử lý tiếng Việt
+        keyEvent.filterAndAccept();
+
+        bool processed = EngineProcessKeyEvent(lotusEngine_.handle(), currentSym, keyEvent.rawKey().states()) != 0U;
+
+        // Trường hợp 1: Bamboo kết thúc từ và trả về chuỗi commit đầy đủ (ví dụ khi gõ phím ngắt từ, dấu câu)
+        auto commitF = UniqueCPtr<char>(EnginePullCommit(lotusEngine_.handle()));
+        if (commitF && (*commitF.get() != 0)) {
+            std::string commitStr = commitF.get();
+            std::string deletedPart;
+            std::string addedPart;
+            compareAndSplitStrings(oldPreBuffer_, commitStr, deletedPart, addedPart);
+
+            hasHistory_ = false;
+            ResetEngine(lotusEngine_.handle());
+            oldPreBuffer_.clear();
+
+            if (!deletedPart.empty()) {
+                performUinputBackspaceReplacement(deletedPart, addedPart);
+                return;
+            }
+            if (!addedPart.empty()) {
+                ic_->commitString(addedPart);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                LOTUS_INFO("UinputBackspace commit: " + addedPart);
+                is_deleting_.store(true, std::memory_order_release);
+                scheduleUinputBackspace(5, [this]() {
+                    is_deleting_.store(false);
+                    replayBufferedKeys();
+                });
+                return;
+            }
+            return;
+        }
+
+        // Trường hợp 2: Bamboo Engine không xử lý phím này (ví dụ phím số, ký tự đặc biệt không ghép từ).
+        // Ta commit trực tiếp ký tự ra ứng dụng, reset bộ đệm từ cũ và áp dụng barrier 5ms để tuần tự hóa phím tiếp theo.
+        if (!processed) {
+            hasHistory_ = false;
+            ResetEngine(lotusEngine_.handle());
+            oldPreBuffer_.clear();
+            ic_->commitString(keyUtf8);
+            lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+            LOTUS_INFO("UinputBackspace commit: " + keyUtf8);
+            is_deleting_.store(true, std::memory_order_release);
+            scheduleUinputBackspace(5, [this]() {
+                is_deleting_.store(false);
+                replayBufferedKeys();
+            });
+            return;
+        }
+
+        hasHistory_ = true;
+        realtextLen.fetch_add(1, std::memory_order_acq_rel);
+
+        UniqueCPtr<char> preeditC(EnginePullPreedit(lotusEngine_.handle()));
+        std::string      preeditStr = (preeditC && (*preeditC.get() != 0)) ? preeditC.get() : "";
+
+        // Trường hợp 3: So sánh trạng thái preedit cũ và mới để tính toán phần cần xóa và phần cần thêm
+        std::string deletedPart;
+        std::string addedPart;
+        if (compareAndSplitStrings(oldPreBuffer_, preeditStr, deletedPart, addedPart) != 0) {
+            if (deletedPart.empty()) {
+                // Chỉ thêm ký tự mới (ví dụ gõ 't' rồi gõ 'h' -> chỉ cần commit thêm 'h')
+                if (!addedPart.empty()) {
+                    oldPreBuffer_ = preeditStr;
+                    ic_->commitString(addedPart);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                    LOTUS_INFO("UinputBackspace commit: " + addedPart);
+                    is_deleting_.store(true, std::memory_order_release);
+                    scheduleUinputBackspace(5, [this]() {
+                        is_deleting_.store(false);
+                        replayBufferedKeys();
+                    });
+                }
+            } else {
+                // Cần xóa ký tự cũ (ví dụ bỏ dấu: 't-h-o-w' -> cần xóa 'o' để thay bằng 'ơ')
+                if (uinput_client_fd_ < 0) {
+                    // Fallback: nếu mất kết nối tới uinput server daemon, commit phím thô để người dùng không bị nuốt phím
+                    LOTUS_ERROR("Cannot connect to uinput server, commit rawkey");
+                    std::string rawKey = keyEvent.key().toString();
+                    if (!rawKey.empty()) {
+                        ic_->commitString(rawKey);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                    }
+                    return;
+                }
+
+                performUinputBackspaceReplacement(deletedPart, addedPart);
                 oldPreBuffer_ = preeditStr;
             }
         }
@@ -1005,7 +1213,12 @@ namespace fcitx {
             LOTUS_WARN("Cannot connect to uinput server, reconnecting....");
             connect_uinput_server();
         }
-        if (current_backspace_count_ >= expected_backspaces_ && is_deleting_.load()) {
+        // Sửa lỗi nghiêm trọng (0 >= 0 bug):
+        // Trong UinputBackspace mode, expected_backspaces_ và current_backspace_count_ không được sử dụng và luôn bằng 0.
+        // Trước đây điều kiện (0 >= 0 && is_deleting_) luôn đúng, khiến is_deleting_ bị tắt ngay lập tức trên mỗi phím bấm,
+        // làm vô hiệu hóa hàng đợi đệm và khiến các phím gõ nhanh đè hỏng trạng thái uinput.
+        // Cần loại trừ UinputBackspace và kiểm tra expected_backspaces_ > 0 để chỉ áp dụng cho Smooth/SuperSmooth mode.
+        if (realMode != LotusMode::UinputBackspace && expected_backspaces_ > 0 && current_backspace_count_ >= expected_backspaces_ && is_deleting_.load()) {
             is_deleting_.store(false);
             current_backspace_count_ = 0;
             expected_backspaces_     = 0;
@@ -1073,6 +1286,13 @@ namespace fcitx {
 
         if (is_deleting_.load(std::memory_order_acquire)) {
             if (isBackspace(currentSym)) {
+                // Phím Backspace do uinput server bắn vào hệ thống được compositor gửi tới Fcitx5:
+                // Đối với UinputBackspace mode, ta forward thẳng ra ứng dụng đích để thực hiện xóa ký tự trên màn hình,
+                // tuyệt đối không nạp vào Bamboo Engine hay xử lý đếm số lượng như Smooth mode để tránh lỗi lặp phím.
+                if (realMode == LotusMode::UinputBackspace) {
+                    keyEvent.forward();
+                    return;
+                }
                 if (realtextLen.load(std::memory_order_acquire) > 0)
                     realtextLen.fetch_sub(1, std::memory_order_acq_rel);
                 if (handleUInputKeyPress(keyEvent, currentSym, (realMode == LotusMode::Smooth || realMode == LotusMode::SuperSmooth) ? 2 : 8)) {
@@ -1127,6 +1347,10 @@ namespace fcitx {
                 handleUinputMode(keyEvent, currentSym);
                 break;
             }
+            case LotusMode::UinputBackspace: {
+                handleUinputBackspaceMode(keyEvent, currentSym);
+                break;
+            }
             case LotusMode::SurroundingText: {
                 handleSurroundingText(keyEvent, currentSym);
                 break;
@@ -1154,7 +1378,11 @@ namespace fcitx {
         const auto& text        = surrounding.text();
         size_t      textLen     = utf8::length(text);
         realtextLen.store(textLen, std::memory_order_release);
-        if (is_deleting_.load(std::memory_order_acquire)) {
+        // Chặn reset ngoài ý muốn:
+        // Khi Fcitx5 hoặc ứng dụng phát tín hiệu reset trong lúc đang gửi phím xóa qua uinput
+        // hoặc trong cửa sổ 50ms sau commit, ta từ chối reset để không xóa mất ngữ cảnh ghép từ tiếng Việt
+        // trong Bamboo Engine (khắc phục lỗi mất dấu / đứt từ khi gõ).
+        if (shouldRejectReset()) {
             return;
         }
         resetMacroSkip();
@@ -1190,7 +1418,8 @@ namespace fcitx {
             case LotusMode::Uinput:
             case LotusMode::Smooth:
             case LotusMode::Minecraft:
-            case LotusMode::SuperSmooth: {
+            case LotusMode::SuperSmooth:
+            case LotusMode::UinputBackspace: {
                 ic_->inputPanel().reset();
                 break;
             }
@@ -1225,7 +1454,8 @@ namespace fcitx {
             case LotusMode::Smooth:
             case LotusMode::SurroundingText:
             case LotusMode::Minecraft:
-            case LotusMode::SuperSmooth: {
+            case LotusMode::SuperSmooth:
+            case LotusMode::UinputBackspace: {
                 if (lotusEngine_) {
                     ResetEngine(lotusEngine_.handle());
                 }
@@ -1239,7 +1469,9 @@ namespace fcitx {
 
     void LotusState::clearAllBuffers() {
         LOTUS_DEBUG("Clear all buffers");
-        if (is_deleting_.load(std::memory_order_acquire)) {
+        // Không xóa buffer nếu đang bận gửi uinput backspace hoặc trong cửa sổ 50ms sau commit
+        // nhằm bảo toàn các biến đệm preedit và lịch sử từ đang gõ dở
+        if (shouldRejectReset()) {
             return;
         }
         resetMacroSkip();
@@ -1253,6 +1485,7 @@ namespace fcitx {
         emojiBuffer_.clear();
         emojiCandidates_.clear();
         buffered_keys_.clear();
+        uinput_commit_timer_.reset();
         shouldCapitalize_  = false;
         isPrevSpace_       = false;
         isPrevHyphen_      = false;
@@ -1270,6 +1503,111 @@ namespace fcitx {
         if (buffered_keys_.empty()) {
             return;
         }
+        if (is_deleting_.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        // Cơ chế Async Serialization cho UinputBackspace mode:
+        // Khác với các mode khác dùng vòng lặp for đồng bộ xả hết phím trong 1 lần (dễ gây tranh chấp
+        // khi phím mới bắn ra trong lúc uinput backspace chưa kịp tới ứng dụng), UinputBackspace
+        // chỉ bốc và xử lý đúng 1 phím đầu hàng đợi (FIFO). Sau khi commit hoặc replace phím đó,
+        // thiết lập barrier 5ms rồi mới tiếp tục gọi replayBufferedKeys() để xử lý phím kế tiếp.
+        if (realMode == LotusMode::UinputBackspace) {
+            auto keyInfo = buffered_keys_.front();
+            buffered_keys_.erase(buffered_keys_.begin());
+
+            auto        sym     = static_cast<KeySym>(keyInfo.sym);
+            uint32_t    state   = keyInfo.state;
+            std::string keyUtf8 = Key::keySymToUTF8(sym);
+            if (keyUtf8.empty()) {
+                replayBufferedKeys();
+                return;
+            }
+
+            bool processed = EngineProcessKeyEvent(lotusEngine_.handle(), sym, state) != 0U;
+
+            auto commitF = UniqueCPtr<char>(EnginePullCommit(lotusEngine_.handle()));
+            if (commitF && (*commitF.get() != 0)) {
+                std::string commitStr = commitF.get();
+                std::string deletedPart;
+                std::string addedPart;
+                compareAndSplitStrings(oldPreBuffer_, commitStr, deletedPart, addedPart);
+
+                hasHistory_ = false;
+                ResetEngine(lotusEngine_.handle());
+                oldPreBuffer_.clear();
+
+                if (!deletedPart.empty()) {
+                    performUinputBackspaceReplacement(deletedPart, addedPart);
+                    return;
+                }
+                if (!addedPart.empty()) {
+                    ic_->commitString(addedPart);
+                    LOTUS_INFO("Replay commit: " + addedPart);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                    is_deleting_.store(true, std::memory_order_release);
+                    scheduleUinputBackspace(5, [this]() {
+                        is_deleting_.store(false);
+                        replayBufferedKeys();
+                    });
+                    return;
+                }
+                replayBufferedKeys();
+                return;
+            }
+
+            if (!processed) {
+                ic_->commitString(keyUtf8);
+                LOTUS_INFO("Replay commit raw: " + keyUtf8);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                is_deleting_.store(true, std::memory_order_release);
+                scheduleUinputBackspace(5, [this]() {
+                    is_deleting_.store(false);
+                    replayBufferedKeys();
+                });
+                return;
+            }
+
+            hasHistory_ = true;
+            realtextLen.fetch_add(1, std::memory_order_acq_rel);
+
+            UniqueCPtr<char> preeditC(EnginePullPreedit(lotusEngine_.handle()));
+            std::string      preeditStr = (preeditC && (*preeditC.get() != 0)) ? preeditC.get() : "";
+
+            std::string      deletedPart;
+            std::string      addedPart;
+            if (compareAndSplitStrings(oldPreBuffer_, preeditStr, deletedPart, addedPart) != 0) {
+                if (deletedPart.empty()) {
+                    if (!addedPart.empty()) {
+                        ic_->commitString(addedPart);
+                        LOTUS_INFO("Replay commit added: " + addedPart);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                        oldPreBuffer_ = preeditStr;
+                        is_deleting_.store(true, std::memory_order_release);
+                        scheduleUinputBackspace(5, [this]() {
+                            is_deleting_.store(false);
+                            replayBufferedKeys();
+                        });
+                        return;
+                    }
+                    replayBufferedKeys();
+                    return;
+                } else {
+                    if (uinput_client_fd_ < 0) {
+                        ic_->commitString(keyUtf8);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
+                        replayBufferedKeys();
+                        return;
+                    }
+                    performUinputBackspaceReplacement(deletedPart, addedPart);
+                    oldPreBuffer_ = preeditStr;
+                    return;
+                }
+            }
+            replayBufferedKeys();
+            return;
+        }
+
         auto keys = std::move(buffered_keys_);
         buffered_keys_.clear();
         for (size_t i = 0; i < keys.size(); ++i) {
@@ -1296,7 +1634,11 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart);
+                    if (realMode == LotusMode::UinputBackspace) {
+                        performUinputBackspaceReplacement(deletedPart, addedPart);
+                    } else {
+                        performReplacement(deletedPart, addedPart);
+                    }
                     hasHistory_ = false;
                     ResetEngine(lotusEngine_.handle());
                     oldPreBuffer_.clear();
@@ -1304,6 +1646,7 @@ namespace fcitx {
                 }
                 if (!addedPart.empty()) {
                     ic_->commitString(addedPart);
+                    lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                 }
 
                 hasHistory_ = false;
@@ -1314,6 +1657,7 @@ namespace fcitx {
 
             if (!processed) {
                 ic_->commitString(keyUtf8);
+                lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                 continue;
             }
 
@@ -1329,11 +1673,13 @@ namespace fcitx {
                 if (deletedPart.empty()) {
                     if (!addedPart.empty()) {
                         ic_->commitString(addedPart);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                         oldPreBuffer_ = preeditStr;
                     }
                 } else {
                     if (uinput_client_fd_ < 0) {
                         ic_->commitString(keyUtf8);
+                        lastCommitTimeUsec_.store(fcitx::now(CLOCK_MONOTONIC), std::memory_order_release);
                         continue;
                     }
 
@@ -1347,7 +1693,11 @@ namespace fcitx {
                             buffered_keys_.push_back(keys[j]);
                         }
                     }
-                    performReplacement(deletedPart, addedPart);
+                    if (realMode == LotusMode::UinputBackspace) {
+                        performUinputBackspaceReplacement(deletedPart, addedPart);
+                    } else {
+                        performReplacement(deletedPart, addedPart);
+                    }
                     oldPreBuffer_ = preeditStr;
                     return;
                 }

--- a/src/lotus-state.h
+++ b/src/lotus-state.h
@@ -20,6 +20,8 @@
 #include "lotus-utils.h"
 
 #include <cstddef>
+#include <functional>
+#include <fcitx-utils/event.h>
 #include <fcitx-utils/misc.h>
 #include <fcitx/inputcontext.h>
 
@@ -98,6 +100,7 @@ namespace fcitx {
         std::string             emojiBuffer_;
         std::vector<EmojiEntry> emojiCandidates_;
         bool                    waitAck_ = false;
+        std::unique_ptr<EventSourceTime> uinput_commit_timer_;
         std::vector<KeyEntry>   buffered_keys_; ///< Keystrokes buffered during replacement
         bool                    isPrevSpace_           = false;
         bool                    isPrevHyphen_          = false;
@@ -198,6 +201,21 @@ namespace fcitx {
          * @param sleepTime Delay in microseconds.
          */
         void handleUinputMode(KeyEvent& keyEvent, KeySym currentSym);
+
+        /**
+         * @brief Handles Uinput (Backspace) mode processing.
+         * @param keyEvent The key event.
+         * @param currentSym Current key symbol.
+         */
+        void handleUinputBackspaceMode(KeyEvent& keyEvent, KeySym currentSym);
+
+        /**
+         * @brief Performs replacement in UinputBackspace mode using server + calculated delay.
+         * @param deletedPart Text to delete.
+         * @param addedPart Text to insert.
+         */
+        void performUinputBackspaceReplacement(const std::string& deletedPart, const std::string& addedPart);
+        void scheduleUinputBackspace(uint32_t delayMs, std::function<void()> callback);
 
         /**
          * @brief Handles surrounding text mode.

--- a/src/lotus-utils.cpp
+++ b/src/lotus-utils.cpp
@@ -25,8 +25,31 @@ std::atomic<bool>             stop_flag_monitor{false};
 std::atomic<int>              uinput_client_fd_{-1};
 std::atomic<unsigned int>     realtextLen{0};
 std::atomic<int>              mouse_socket_fd{-1};
+std::atomic<uint64_t>         lastCommitTimeUsec_{0};
 
 FCITX_DEFINE_LOG_CATEGORY(lotus, "lotus", fcitx::LogLevel::NoLog);
+
+// Kiểm tra xem có nên từ chối yêu cầu reset từ ứng dụng/compositor hay không.
+// Khi gõ tiếng Việt (đặc biệt trong các app như Chrome, Electron, Qt, GTK):
+// 1. Quá trình gửi phím Backspace qua uinput hoặc commit ký tự mới thường kích hoạt sự kiện reset từ app gửi về Fcitx5.
+// 2. Nếu chấp nhận reset lúc này, Bamboo Engine sẽ bị reset về trạng thái ban đầu, làm mất toàn bộ ngữ cảnh từ đang gõ dở
+//    dẫn đến các lỗi kinh điển: mất dấu, nhảy chữ, gõ 'tiếng' thành 'tiế ng', v.v.
+// Vì vậy: Chặn triệt để reset nếu:
+// - Đang bận gửi phím xóa qua uinput (is_deleting_ == true)
+// - Hoặc vừa mới commit xong ký tự thay thế trong cửa sổ an toàn 50ms (lastCommitTimeUsec_)
+bool shouldRejectReset() {
+    if (is_deleting_.load(std::memory_order_acquire)) {
+        return true;
+    }
+    uint64_t lastCommit = lastCommitTimeUsec_.load(std::memory_order_acquire);
+    if (lastCommit != 0) {
+        uint64_t now = fcitx::now(CLOCK_MONOTONIC);
+        if (now >= lastCommit && (now - lastCommit) <= 50000) { // Cửa sổ an toàn 50ms (50,000 microsecond) sau commit
+            return true;
+        }
+    }
+    return false;
+}
 
 std::string buildSocketPath(const char* base_path_suffix) {
     struct passwd  pwd{};

--- a/src/lotus-utils.h
+++ b/src/lotus-utils.h
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <sys/un.h>
 #include <fcitx-utils/log.h>
+#include <fcitx-utils/misc.h>
+#include <fcitx-utils/eventloopinterface.h>
 #include <fcitx/inputcontext.h>
 
 #include "lotus-config.h"
@@ -58,6 +60,14 @@ std::string buildSocketPath(const char* base_path_suffix);
  * @return Timestamp in milliseconds.
  */
 int64_t now_ms();
+
+extern std::atomic<uint64_t> lastCommitTimeUsec_; ///< Timestamp of last rewrite completion in microseconds
+
+/**
+ * @brief Checks whether reset/activate/deactivate should be rejected.
+ * Rejects if deletion is active or within 50ms post-commit window.
+ */
+bool shouldRejectReset();
 
 /**
  * @brief Checks if key symbol is a backspace.


### PR DESCRIPTION
…tion

- Add UinputBackspace mode using uinput server backspaces with calculated delay
- Implement shouldRejectReset() to prevent engine reset during active deletion and 50ms post-commit window
- Fix 0 >= 0 bug in keyEvent where is_deleting_ was prematurely reset
- Implement single-key async FIFO replay with 20ms post-commit barrier in replayBufferedKeys
- Forward compositor-bounced backspaces directly to destination app
- Add configuration options, shortcuts, and GUI settings support for Uinput (Backspace) mode

# Mô tả

<!-- Mô tả rõ ràng và chi tiết thay đổi của bạn: vấn đề gì, giải quyết thế nào. -->

## Loại thay đổi

- [x] Tính năng mới
- [x] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD

## Liên kết issue
https://github.com/LotusInputMethod/fcitx5-lotus/issues/441
<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [x] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [x] Build C++ thành công (`cmake .. && make`)
- [x] Test pass (`cd bamboo/ && go test -race ./...`)
- [x] Đã rebase với nhánh `dev` mới nhất
- [ ] Các CI checks pass:
