### PR TITLE
ci: reduce CI time and redundant test compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
           path: fcitx5-lotus
           submodules: true
       - name: Init CodeQL
+        if: matrix.compiler == 'gcc'
         uses: github/codeql-action/init@v4.37.9
         with:
           languages: cpp,go
@@ -88,6 +89,7 @@ jobs:
         run: |
           ctest --test-dir fcitx5-lotus/build --output-on-failure --no-tests=error
       - name: CodeQL Analysis
+        if: matrix.compiler == 'gcc'
         uses: github/codeql-action/analyze@v4.37.9
         with:
           checkout_path: fcitx5-lotus

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
 
   check:
     name: Build and test
-    needs: clang-format
     runs-on: ubuntu-latest
     container: archlinux:latest
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,24 @@
+# Reusable object library compiling the 7 core Lotus sources once per compiler build,
+# shared across all headless integration test executables.
+add_library(lotus_test_core OBJECT ${fcitx_lotus_core_sources})
+set_target_properties(lotus_test_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(lotus_test_core PRIVATE
+    ${PROJECT_BINARY_DIR}
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_compile_definitions(lotus_test_core PRIVATE
+    FCITX5_LOTUS_SETTINGS_PATH="${CMAKE_INSTALL_FULL_BINDIR}/fcitx5-lotus-settings"
+    FCITX_LOTUS_ICON_DIR="${CMAKE_INSTALL_FULL_DATADIR}/icons/hicolor/scalable/apps"
+)
+target_link_libraries(lotus_test_core PRIVATE
+    Fcitx5::Core
+    Fcitx5::Config
+    Fcitx5::Module::Emoji
+    Bamboo::Core
+    Pthread::Pthread
+    X11::X11
+)
+
 # Helper macro to compile standalone headless integration test linked with Lotus engine.
 #
 # Usage:
@@ -5,7 +26,7 @@
 # Example:
 #   add_lotus_headless_test(my_test my-test.cpp "integration;myfeature")
 function(add_lotus_headless_test target source labels)
-    add_executable(${target} ${source} ${fcitx_lotus_core_sources})
+    add_executable(${target} ${source} $<TARGET_OBJECTS:lotus_test_core>)
     target_include_directories(${target} PRIVATE
         ${PROJECT_BINARY_DIR}
         ${PROJECT_SOURCE_DIR}/src


### PR DESCRIPTION
Following the headless test harness added in #451, the GCC/Clang build matrix became the dominant part of CI runtime.

This PR reduces avoidable work in the test build and CI dependency graph without changing production sources.

## Changes

* Reuse the seven shared Lotus core sources across the six headless integration tests through a `lotus_test_core` CMake OBJECT library.

  * This removes 35 repeated core-source compilations.
  * The Ninja build graph drops from 95 to 60 targets.

* Run CodeQL only on the GCC matrix leg.

  * The Clang leg still builds and runs the same test suite, but without CodeQL instrumentation.

* Remove the remaining `needs: clang-format` dependency from the GCC/Clang build matrix.

  * The build jobs can now be scheduled independently of the formatting job.

The PR only changes CI workflow and test build configuration; no files under `src/` are modified.

## Benchmark

A/B benchmark on the same fork, using a baseline pinned to `f4ee63c` and the current PR HEAD `8b254b2`.

Each side was run 5 times using reruns of the same workflow revision.

| Metric                   |     Baseline |           PR | Change |
| ------------------------ | -----------: | -----------: | -----: |
| Median workflow duration | 551s (~9.2m) | 343s (~5.7m) | -37.7% |
| Relative speedup         |              |              |  1.61× |
| Ninja build targets      |           95 |           60 |    -35 |

Workflow-duration samples:

* Baseline: 511s, 611s, 551s, 600s, 525s
* PR: 293s, 343s, 347s, 375s, 301s

Benchmark runs:

* Baseline: [run 34159706756][baseline-run], attempts 1–5
* PR HEAD: [run 34174053763][benchmark-run], attempts 1–5


[baseline-run]: https://github.com/naoNao89/fcitx5-lotus/actions/runs/34159706756
[benchmark-run]: https://github.com/naoNao89/fcitx5-lotus/actions/runs/34174053763
[pr-ci]: https://github.com/LotusInputMethod/fcitx5-lotus/actions/runs/34189465744
