### PR TITLE
fix: edge case type english with number when macro enable

### DIFF
--- a/bamboo/fcitxbambooengine.go
+++ b/bamboo/fcitxbambooengine.go
@@ -285,7 +285,11 @@ func (e *FcitxBambooEngine) getCommitText(keyVal, state uint32, oldText string) 
 		e.preeditor.RestoreLastWord(!bamboo.HasAnyVietnameseRune(oldText))
 		return e.getPreeditString(), false
 	}
-	if e.preeditor.CanProcessKey(keyRune) || (e.macroEnabled && keyRune >= '0' && keyRune <= '9') {
+	canProcess := e.preeditor.CanProcessKey(keyRune)
+	if canProcess || (e.macroEnabled && keyRune >= '0' && keyRune <= '9') {
+		if !canProcess && e.shouldFallbackToEnglish(true) {
+			e.preeditor.RestoreLastWord(false)
+		}
 		if state&FcitxLockMask != 0 {
 			keyRune = e.toUpper(keyRune)
 		}

--- a/bamboo/fcitxbambooengine_test.go
+++ b/bamboo/fcitxbambooengine_test.go
@@ -393,3 +393,25 @@ func TestIsValidState(t *testing.T) {
 		}
 	}
 }
+
+func TestEnglishNumberW2UInMacroMode(t *testing.T) {
+	cases := []struct {
+		keys string
+		want string
+	}{
+		{"qwen2", "qwen2"},
+		{"new1", "new1"},
+	}
+
+	for _, c := range cases {
+		e := newTestEngine(nil, false)
+		e.macroEnabled = true
+		e.autoNonVnRestore = true
+		e.w2u = true
+
+		typeKeys(e, c.keys)
+		if got := e.preeditText; got != c.want {
+			t.Errorf("type [%s] preedit got [%s] expected [%s]", c.keys, got, c.want)
+		}
+	}
+}

--- a/bamboo/fcitxbambooengine_test.go
+++ b/bamboo/fcitxbambooengine_test.go
@@ -395,23 +395,19 @@ func TestIsValidState(t *testing.T) {
 }
 
 func TestEnglishNumberW2UInMacroMode(t *testing.T) {
-	cases := []struct {
-		keys string
-		want string
-	}{
-		{"qwen2", "qwen2"},
-		{"new1", "new1"},
+	e := newTestEngine(nil, false)
+	e.macroEnabled = true
+	e.w2u = true
+
+	typeKeys(e, "qwen2")
+	if got := e.preeditText; got != "qwen2" {
+		t.Errorf("type [qwen2] preedit got [%s] expected [qwen2]", got)
 	}
 
-	for _, c := range cases {
-		e := newTestEngine(nil, false)
-		e.macroEnabled = true
-		e.autoNonVnRestore = true
-		e.w2u = true
+	e.commitPreeditAndReset("")
 
-		typeKeys(e, c.keys)
-		if got := e.preeditText; got != c.want {
-			t.Errorf("type [%s] preedit got [%s] expected [%s]", c.keys, got, c.want)
-		}
+	typeKeys(e, "new1")
+	if got := e.preeditText; got != "new1" {
+		t.Errorf("type [new1] preedit got [%s] expected [new1]", got)
 	}
 }


### PR DESCRIPTION
# Mô tả

<!-- Mô tả rõ ràng và chi tiết thay đổi của bạn: vấn đề gì, giải quyết thế nào. -->
sửa lỗi khi bật macro, bật Type w to Produce ư thì gõ qwen2 thành qưen2, new1 thành neư1

## Loại thay đổi

- [ ] Tính năng mới
- [x] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [ ] Cải tiến CI/CD

## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [ ] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [x] Build C++ thành công (`cmake .. && make`)
- [x] Test pass (`cd bamboo/ && go test -race ./...`)
- [x] Đã rebase với nhánh `dev` mới nhất
- [ ] Các CI checks pass: