### PR TITLE
Update Nix package file and add hash update workflow

### DIFF
--- a/.github/workflows/update-nix-hash.yaml
+++ b/.github/workflows/update-nix-hash.yaml
@@ -1,0 +1,89 @@
+name: Update Nix Hash on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Update version:'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-nix-hash
+  cancel-in-progress: false
+
+jobs:
+  update-hash:
+    name: Update package hash
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Run nix-update via shim
+        run: |
+          cat > update-shim.nix << 'EOF'
+          { pkgs ? import <nixpkgs> { } }:
+          {
+            fcitx5-lotus = pkgs.callPackage ./nix/packages/fcitx5-lotus { };
+          }
+          EOF
+
+          nix run nixpkgs#nix-update -- \
+            --file ./update-shim.nix \
+            fcitx5-lotus \
+            --version="${{ steps.version.outputs.version }}"
+
+          rm update-shim.nix
+
+      - name: Build to verify
+        run: nix build -L --no-link .#packages.x86_64-linux.fcitx5-lotus
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.git-check.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: main
+          commit-message: "nix: update fcitx5-lotus to ${{ steps.version.outputs.version }}"
+          title: "nix: update to v${{ steps.version.outputs.version }}"
+          body: |
+            Tự động cập nhật version và hash cho Nix sau khi release `v${{ steps.version.outputs.version }}`.
+            Đã build thành công trước khi tạo PR này.
+          branch: auto-update-nix-${{ steps.version.outputs.version }}
+          delete-branch: true

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765361626,
-        "narHash": "sha256-kX0Dp/kYSRbQ+yd9e3lmmUWdNbipufvKfL2IzbrSpnY=",
+        "lastModified": 1784328457,
+        "narHash": "sha256-4R5WV74NHhPk21ctoPmjL7nQ6txDnoBLwSWULvIw0TY=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "c566ad8b7352c30ec3763435de7c8f1c46ebb357",
+        "rev": "6ee3542cb459ca4b038cfe50ceb8797f05cdabad",
         "type": "github"
       },
       "original": {

--- a/nix/packages/fcitx5-lotus/default.nix
+++ b/nix/packages/fcitx5-lotus/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "LotusInputMethod";
     repo = "fcitx5-lotus";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-kOIs8nLSF93xDIU7v8Wldyw+Zs5NEMJqZA/42TN4oYM=";
     fetchSubmodules = true;
   };

--- a/nix/packages/fcitx5-lotus/default.nix
+++ b/nix/packages/fcitx5-lotus/default.nix
@@ -13,6 +13,7 @@
   libinput,
   librsvg,
   libx11,
+  nix-update-script,
   pkg-config,
   python3,
   qt6,
@@ -35,9 +36,23 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "LotusInputMethod";
     repo = "fcitx5-lotus";
-    tag = "v${finalAttrs.version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-kOIs8nLSF93xDIU7v8Wldyw+Zs5NEMJqZA/42TN4oYM=";
     fetchSubmodules = true;
+  };
+
+  vendorDir = finalAttrs.passthru."go-modules";
+
+  passthru = {
+    "go-modules" =
+      (buildGoModule {
+        pname = "fcitx5-lotus-go-modules";
+        inherit (finalAttrs) version src;
+        modRoot = "bamboo";
+        vendorHash = "sha256-CNDYjxDfqh9nGs5vlpb/7qXZeNtkvegC5nPvBOZcDrc=";
+      }).goModules;
+
+    updateScript = nix-update-script { };
   };
 
   nativeBuildInputs = [
@@ -63,13 +78,11 @@ stdenv.mkDerivation (finalAttrs: {
     udev
   ];
 
-  vendorDir =
-    (buildGoModule {
-      pname = "fcitx5-lotus-go-modules";
-      inherit (finalAttrs) version src;
-      modRoot = "bamboo";
-      vendorHash = "sha256-CNDYjxDfqh9nGs5vlpb/7qXZeNtkvegC5nPvBOZcDrc=";
-    }).goModules;
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  dontWrapQtApps = true;
 
   preConfigure = ''
     export GOCACHE=$TMPDIR/go-cache
@@ -113,10 +126,16 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix XDG_DATA_DIRS : "${hicolor-icon-theme}/share"
   '';
 
-  meta = with lib; {
-    description = "Fcitx5 Lotus input method for Vietnamese typing";
+  meta = {
+    description = "Vietnamese input method engine for Fcitx5";
     homepage = "https://github.com/LotusInputMethod/fcitx5-lotus";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = with lib.licenses; [
+      gpl3Plus
+      lgpl21Plus
+    ];
+    maintainers = with lib.maintainers; [
+      justanoobcoder
+    ];
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
# Mô tả

PR này thêm github workflow tự động cập nhật hash của Nix thay vì phải làm thủ công.

Cụ thể thì mỗi khi có release mới, nó sẽ chạy workflow lấy và cập nhật hash (cả hash src và hash go modules nếu có thay đổi), các thay đổi sẽ được commit trên 1 branch mới tên `auto-update-nix-<version>`, branch này được tạo từ `main`. Workflow này đồng thời cũng build lotus trên Nix. Sau đó, nó tạo PR trỏ vào `main`. Bạn chỉ cần approve PR rồi delete branch auto-update là xong. Workflow này cũng có thể được trigger thủ công bằng việc điền version cần update vào input của workflow.

Note: cần cấp quyền write và tạo PR cho github action.

## Loại thay đổi

- [ ] Tính năng mới
- [ ] Sửa lỗi
- [ ] Cải thiện hiệu năng
- [ ] Cập nhật tài liệu
- [x] Cải tiến CI/CD

## Liên kết issue

<!-- Fixes #123 (nếu có) -->

## Screenshot (cho UI changes)

<!-- Dán screenshot trước/sau nếu thay đổi giao diện -->

# Checklist

- [x] Nhánh đích là `dev` (KHÔNG phải `main`)
- [x] Đã chạy `clang-format` (tuân thủ `.clang-format`)
- [x] Đã kiểm tra `ruff check` và `ruff format` (cho phần Python `settings-gui`)
- [x] Build C++ thành công (`cmake .. && make`)
- [x] Test pass (`cd bamboo/ && go test -race ./...`)
- [x] Đã rebase với nhánh `dev` mới nhất
- [x] Các CI checks pass:
