### PR TITLE
fix(monitor): chặn cận độ dài khi ghi nhật ký socket chuột, bản dựng hết cảnh báo

### DIFF
--- a/src/lotus-monitor.cpp
+++ b/src/lotus-monitor.cpp
@@ -8,6 +8,7 @@
 #include "lotus-monitor.h"
 #include "lotus-utils.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -110,7 +111,10 @@ void mousePressResetThread() {
                     needEngineReset.store(true, std::memory_order_release);
                     g_mouse_clicked.store(true, std::memory_order_release);
                 } else {
-                    LOTUS_WARN("Unexpected message received from mouse socket: " + std::string(buf, n));
+                    // Clamp for the compiler's benefit: n is already known to be in [1, sizeof(buf)]
+                    // here, but GCC cannot prove it and warns that the length may be a huge size_t.
+                    const size_t len = std::min(static_cast<size_t>(n), sizeof(buf));
+                    LOTUS_WARN("Unexpected message received from mouse socket: " + std::string(buf, len));
                 }
 
             } else if (ret < 0 && errno != EINTR) {


### PR DESCRIPTION
Dựng `dev` bằng GCC 16 thì cả bản dựng chỉ còn **đúng một cảnh báo**, và đây là nó:

```
char_traits.h:432:56: warning: '__builtin_memcpy' accessing between
9223372036854775760 and 9223372036854775806 bytes ... [-Wrestrict]
inlined from 'void mousePressResetThread()' at src/lotus-monitor.cpp:113
```

**Không phải lỗi đọc tràn thật.** `n` là giá trị `recv` trả về với đệm 16 byte, và nhánh `n <= 0` đã `break` ở trên, nên tới dòng đó `n` chắc chắn nằm trong `[1, sizeof(buf)]`. Chỉ là GCC không chứng minh được cận trên nên nó giả định `ssize_t` có thể vọt lên cỡ `size_t`.

Chặn cận làm điều kiện đó thành tường minh, và bản dựng sạch cảnh báo.

Mình nghĩ đáng sửa vì nó là cảnh báo cuối cùng còn lại: một cảnh báo lúc nào cũng hiện sẽ tập cho người ta quen mắt lướt qua, rồi cảnh báo thật sau này cũng bị lướt qua luôn.

`ctest` 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvNe693ge85eB4QPs6hpjV
